### PR TITLE
feat(墨迹渐隐): 添加在笔工具菜单中隐藏墨迹渐隐控制开关的功能

### DIFF
--- a/Ink Canvas/MainWindow.xaml
+++ b/Ink Canvas/MainWindow.xaml
@@ -860,7 +860,7 @@
                                                          IsOn="False" FontFamily="Microsoft YaHei UI" FontWeight="Bold"
                                                          Toggled="ToggleSwitchHideInkFadeControlInPenMenu_Toggled" />
                                     </ui:SimpleStackPanel>
-                                    <TextBlock Text="# 开启后，主工具栏上点击笔工具后弹出的上下文菜单中将不显示墨迹渐隐控制开关，可以有效防止课间老是有人玩墨迹渐隐功能" TextWrapping="Wrap" Foreground="#a1a1aa" />
+                                    <TextBlock Text="# 开启后，主工具栏上点击笔工具后弹出的上下文菜单中将不显示墨迹渐隐控制开关" TextWrapping="Wrap" Foreground="#a1a1aa" />
 
                                 </ui:SimpleStackPanel>
                             </GroupBox>

--- a/Ink Canvas/MainWindow.xaml
+++ b/Ink Canvas/MainWindow.xaml
@@ -851,6 +851,16 @@
                                         <TextBlock Foreground="#fafafa" Text="{Binding ElementName=InkFadeTimeSlider, Path=Value, StringFormat={}{0:0}ms}" 
                                                    VerticalAlignment="Center" FontSize="14" Margin="16,0,0,0" />
                                     </ui:SimpleStackPanel>
+                                    <Line HorizontalAlignment="Center" X1="0" Y1="0" X2="400" Y2="0" Stroke="#3f3f46"
+                                          StrokeThickness="1" Margin="0,4,0,4" />
+                                    <ui:SimpleStackPanel Orientation="Horizontal" HorizontalAlignment="Left">
+                                        <TextBlock Foreground="#fafafa" Text="在笔工具菜单中隐藏墨迹渐隐控制" VerticalAlignment="Center"
+                                                   FontSize="14" Margin="0,0,16,0" />
+                                        <ui:ToggleSwitch OnContent="" OffContent="" Name="ToggleSwitchHideInkFadeControlInPenMenu"
+                                                         IsOn="False" FontFamily="Microsoft YaHei UI" FontWeight="Bold"
+                                                         Toggled="ToggleSwitchHideInkFadeControlInPenMenu_Toggled" />
+                                    </ui:SimpleStackPanel>
+                                    <TextBlock Text="# 开启后，主工具栏上点击笔工具后弹出的上下文菜单中将不显示墨迹渐隐控制开关，可以有效防止课间老是有人玩墨迹渐隐功能" TextWrapping="Wrap" Foreground="#a1a1aa" />
 
                                 </ui:SimpleStackPanel>
                             </GroupBox>
@@ -5296,7 +5306,7 @@
                                                                             IsOn="{Binding ElementName=ToggleSwitchEnableInkToShape, Path=IsOn}" />
                                                                     </ui:SimpleStackPanel>
                                                                     <ui:SimpleStackPanel Orientation="Horizontal"
-                                                                        Width="100">
+                                                                        Width="100" x:Name="InkFadeControlPanel1">
                                                                         <Label Margin="0,0,10,0" Content="墨迹渐隐"
                                                                             Foreground="{DynamicResource FloatBarForeground}"
                                                                             FontSize="12"
@@ -8320,7 +8330,7 @@
                                                                         IsOn="{Binding ElementName=ToggleSwitchEnableInkToShape, Path=IsOn}" />
                                                                 </ui:SimpleStackPanel>
                                                                 <ui:SimpleStackPanel Orientation="Horizontal"
-                                                                    Width="100">
+                                                                    Width="100" x:Name="InkFadeControlPanel2">
                                                                     <Label Margin="0,0,10,0" Content="墨迹渐隐"
                                                                            Foreground="{DynamicResource FloatBarForeground}"
                                                                            FontSize="12" VerticalAlignment="Center" />

--- a/Ink Canvas/MainWindow.xaml.cs
+++ b/Ink Canvas/MainWindow.xaml.cs
@@ -2693,6 +2693,57 @@ namespace Ink_Canvas
         }
 
         /// <summary>
+        /// 在笔工具菜单中隐藏墨迹渐隐控制开关切换事件处理
+        /// </summary>
+        private void ToggleSwitchHideInkFadeControlInPenMenu_Toggled(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                if (isLoaded)
+                {
+                    Settings.Canvas.HideInkFadeControlInPenMenu = ToggleSwitchHideInkFadeControlInPenMenu.IsOn;
+                    SaveSettingsToFile();
+                }
+
+                // 立即更新墨迹渐隐控制开关的可见性
+                UpdateInkFadeControlVisibility();
+
+                LogHelper.WriteLogToFile($"在笔工具菜单中隐藏墨迹渐隐控制开关已{(Settings.Canvas.HideInkFadeControlInPenMenu ? "启用" : "禁用")}", LogHelper.LogType.Event);
+            }
+            catch (Exception ex)
+            {
+                LogHelper.WriteLogToFile($"切换在笔工具菜单中隐藏墨迹渐隐控制开关时出错: {ex.Message}", LogHelper.LogType.Error);
+            }
+        }
+
+        /// <summary>
+        /// 更新墨迹渐隐控制开关的可见性
+        /// </summary>
+        private void UpdateInkFadeControlVisibility()
+        {
+            try
+            {
+                bool isHidden = Settings.Canvas.HideInkFadeControlInPenMenu;
+
+                // 控制 InkFadeControlPanel1（批注子面板中）的可见性
+                if (InkFadeControlPanel1 != null)
+                {
+                    InkFadeControlPanel1.Visibility = isHidden ? Visibility.Collapsed : Visibility.Visible;
+                }
+
+                // 控制 InkFadeControlPanel2（普通画笔面板中）的可见性
+                if (InkFadeControlPanel2 != null)
+                {
+                    InkFadeControlPanel2.Visibility = isHidden ? Visibility.Collapsed : Visibility.Visible;
+                }
+            }
+            catch (Exception ex)
+            {
+                LogHelper.WriteLogToFile($"更新墨迹渐隐控制面板可见性时出错: {ex.Message}", LogHelper.LogType.Error);
+            }
+        }
+
+        /// <summary>
         /// PPT放映模式显示手势按钮开关切换事件处理
         /// </summary>
         private void ToggleSwitchShowGestureButtonInSlideShow_Toggled(object sender, RoutedEventArgs e)

--- a/Ink Canvas/MainWindow_cs/MW_SettingsToLoad.cs
+++ b/Ink Canvas/MainWindow_cs/MW_SettingsToLoad.cs
@@ -1205,6 +1205,15 @@ namespace Ink_Canvas
                     _inkFadeManager.UpdateFadeTime(Settings.Canvas.InkFadeTime);
                 }
 
+                // 同步在笔工具菜单中隐藏墨迹渐隐控制开关的设置
+                if (ToggleSwitchHideInkFadeControlInPenMenu != null)
+                {
+                    ToggleSwitchHideInkFadeControlInPenMenu.IsOn = Settings.Canvas.HideInkFadeControlInPenMenu;
+                }
+
+                // 根据设置更新墨迹渐隐控制开关的可见性
+                UpdateInkFadeControlVisibility();
+
                 LogHelper.WriteLogToFile("墨迹渐隐设置已加载", LogHelper.LogType.Event);
             }
             catch (Exception ex)

--- a/Ink Canvas/Resources/Settings.cs
+++ b/Ink Canvas/Resources/Settings.cs
@@ -106,6 +106,8 @@ namespace Ink_Canvas
         public bool EnableInkFade { get; set; } = false;
         [JsonProperty("inkFadeTime")]
         public int InkFadeTime { get; set; } = 3000; // 墨迹渐隐时间（毫秒）
+        [JsonProperty("hideInkFadeControlInPenMenu")]
+        public bool HideInkFadeControlInPenMenu { get; set; } = false; // 是否在笔工具菜单中隐藏墨迹渐隐控制开关
 
     }
 

--- a/Ink Canvas/Windows/SettingsViews/SettingsViews/CanvasAndInkPanel.xaml
+++ b/Ink Canvas/Windows/SettingsViews/SettingsViews/CanvasAndInkPanel.xaml
@@ -249,6 +249,20 @@
                             <TextBlock x:Name="InkFadeTimeText" Text="3000ms" VerticalAlignment="Center" FontSize="14" Margin="12,0,0,0" Foreground="#2e3436"/>
                         </StackPanel>
                     </Grid>
+                    <Border Height="1" Background="#ebebeb"/>
+                    <Grid Height="54">
+                        <StackPanel Orientation="Vertical" Margin="18,0,0,0" VerticalAlignment="Center" HorizontalAlignment="Left">
+                            <TextBlock Foreground="#2e3436" FontSize="14.5" Text="在笔工具菜单中隐藏墨迹渐隐控制" HorizontalAlignment="Left"/>
+                            <TextBlock Foreground="#9a9996" FontSize="11" Margin="0,3.5,0,0" Text="开启后，主工具栏上点击笔工具后弹出的上下文菜单中将不显示墨迹渐隐控制开关" HorizontalAlignment="Left"/>
+                        </StackPanel>
+                        <Border x:Name="ToggleSwitchHideInkFadeControlInPenMenu" Style="{StaticResource ToggleSwitchStyle}" Background="#e1e1e1" Tag="HideInkFadeControlInPenMenu" MouseLeftButtonDown="ToggleSwitch_Click">
+                            <Border Width="19" Height="19" Background="White" CornerRadius="10" HorizontalAlignment="Left" VerticalAlignment="Center">
+                                <Border.Effect>
+                                    <DropShadowEffect BlurRadius="4" Direction="-45" Color="Black" Opacity="0.3" ShadowDepth="0"/>
+                                </Border.Effect>
+                            </Border>
+                        </Border>
+                    </Grid>
                 </StackPanel>
             </Border>
             

--- a/Ink Canvas/Windows/SettingsViews/SettingsViews/CanvasAndInkPanel.xaml.cs
+++ b/Ink Canvas/Windows/SettingsViews/SettingsViews/CanvasAndInkPanel.xaml.cs
@@ -360,6 +360,11 @@ namespace Ink_Canvas.Windows.SettingsViews
                     }
                     break;
 
+                case "HideInkFadeControlInPenMenu":
+                    // 调用 MainWindow 中的方法
+                    MainWindowSettingsHelper.InvokeToggleSwitchToggled("ToggleSwitchHideInkFadeControlInPenMenu", newState);
+                    break;
+
                 case "EnableAutoSaveStrokes":
                     // 调用 MainWindow 中的方法
                     MainWindowSettingsHelper.InvokeToggleSwitchToggled("ToggleSwitchEnableAutoSaveStrokes", newState);


### PR DESCRIPTION
添加新设置选项，允许用户在笔工具菜单中隐藏墨迹渐隐控制开关。该功能包括：
- 新增设置属性 HideInkFadeControlInPenMenu
- 在设置界面添加对应的开关控件
- 实现开关状态同步和可见性更新逻辑
- 更新主界面笔工具菜单中的控制面板可见性

终于不怕课间有人玩墨迹渐隐了！！！