### PR TITLE
添加注册uri的功能

### DIFF
--- a/Ink Canvas/Helpers/UriSchemeHelper.cs
+++ b/Ink Canvas/Helpers/UriSchemeHelper.cs
@@ -1,0 +1,89 @@
+using Microsoft.Win32;
+using System;
+using System.Diagnostics;
+using System.Security;
+
+namespace Ink_Canvas.Helpers
+{
+    public static class UriSchemeHelper
+    {
+        private const string SchemeName = "icc";
+        private const string FriendlyName = "URL:Ink Canvas Protocol";
+
+        public static bool RegisterUriScheme()
+        {
+            try
+            {
+                string exePath = Process.GetCurrentProcess().MainModule.FileName;
+
+                // 使用 CurrentUser\Software\Classes 代替 ClassesRoot，无需管理员权限
+                using (RegistryKey key = Registry.CurrentUser.CreateSubKey(@"Software\Classes\" + SchemeName))
+                {
+                    key.SetValue("", FriendlyName);
+                    key.SetValue("URL Protocol", "");
+
+                    using (RegistryKey defaultIconKey = key.CreateSubKey("DefaultIcon"))
+                    {
+                        // 修正引号转义
+                        defaultIconKey.SetValue("", "\"" + exePath + "\",1");
+                    }
+
+                    using (RegistryKey shellKey = key.CreateSubKey("shell"))
+                    using (RegistryKey openKey = shellKey.CreateSubKey("open"))
+                    using (RegistryKey commandKey = openKey.CreateSubKey("command"))
+                    {
+                        // 修正引号转义
+                        commandKey.SetValue("", "\"" + exePath + "\" \"%1\"");
+                    }
+                }
+                LogHelper.WriteLogToFile($"成功注册URI Scheme: {SchemeName}://", LogHelper.LogType.Event);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                LogHelper.WriteLogToFile($"注册URI Scheme失败: {ex.Message}", LogHelper.LogType.Error);
+                return false;
+            }
+        }
+
+        public static bool UnregisterUriScheme()
+        {
+            try
+            {
+                // 使用 CurrentUser\Software\Classes
+                Registry.CurrentUser.DeleteSubKeyTree(@"Software\Classes\" + SchemeName, false);
+                LogHelper.WriteLogToFile($"成功注销URI Scheme: {SchemeName}://", LogHelper.LogType.Event);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                LogHelper.WriteLogToFile($"注销URI Scheme失败: {ex.Message}", LogHelper.LogType.Error);
+                return false;
+            }
+        }
+
+        public static bool IsUriSchemeRegistered()
+        {
+            try
+            {
+                // 使用 CurrentUser\Software\Classes
+                using (RegistryKey key = Registry.CurrentUser.OpenSubKey(@"Software\Classes\" + SchemeName))
+                {
+                    if (key == null) return false;
+                    // 修正反斜杠路径
+                    using (RegistryKey shellKey = key.OpenSubKey(@"shell\open\command"))
+                    {
+                        if (shellKey == null) return false;
+                        string command = shellKey.GetValue("") as string;
+                        string exePath = Process.GetCurrentProcess().MainModule.FileName;
+                        return !string.IsNullOrEmpty(command) && command.Contains(exePath);
+                    }
+                }
+            }
+            catch
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/Ink Canvas/MainWindow.xaml
+++ b/Ink Canvas/MainWindow.xaml
@@ -2417,6 +2417,9 @@
                                         <ui:ToggleSwitch OnContent="" OffContent="" Name="ToggleSwitchIsSpecialScreen"
                                                          IsOn="True" FontFamily="Microsoft YaHei UI" FontWeight="Bold"
                                                          Toggled="ToggleSwitchIsSpecialScreen_OnToggled" />
+                                        <ui:ToggleSwitch OnContent="" OffContent="" Name="ToggleSwitchIsEnableUriScheme"
+                                                         Visibility="Collapsed" IsOn="False"
+                                                         Toggled="ToggleSwitchIsEnableUriScheme_Toggled" />
                                     </ui:SimpleStackPanel>
                                     <StackPanel Orientation="Vertical">
                                         <TextBlock Foreground="#fafafa" Text="触摸倍数" VerticalAlignment="Center"

--- a/Ink Canvas/MainWindow_cs/MW_Settings.cs
+++ b/Ink Canvas/MainWindow_cs/MW_Settings.cs
@@ -2853,6 +2853,29 @@ namespace Ink_Canvas
             SaveSettingsToFile();
         }
 
+        private void ToggleSwitchIsEnableUriScheme_Toggled(object sender, RoutedEventArgs e)
+        {
+            if (!isLoaded) return;
+            Settings.Advanced.IsEnableUriScheme = ToggleSwitchIsEnableUriScheme.IsOn;
+
+            if (Settings.Advanced.IsEnableUriScheme)
+            {
+                if (!UriSchemeHelper.IsUriSchemeRegistered())
+                {
+                    UriSchemeHelper.RegisterUriScheme();
+                }
+            }
+            else
+            {
+                if (UriSchemeHelper.IsUriSchemeRegistered())
+                {
+                    UriSchemeHelper.UnregisterUriScheme();
+                }
+            }
+
+            SaveSettingsToFile();
+        }
+
         private void TouchMultiplierSlider_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
         {
             if (!isLoaded) return;

--- a/Ink Canvas/MainWindow_cs/MW_SettingsToLoad.cs
+++ b/Ink Canvas/MainWindow_cs/MW_SettingsToLoad.cs
@@ -857,6 +857,7 @@ namespace Ink_Canvas
                 ToggleSwitchIsSecondConfimeWhenShutdownApp.IsOn = Settings.Advanced.IsSecondConfirmWhenShutdownApp;
                 ToggleSwitchWindowMode.IsOn = Settings.Advanced.WindowMode;
                 ToggleSwitchIsSpecialScreen.IsOn = Settings.Advanced.IsSpecialScreen;
+                ToggleSwitchIsEnableUriScheme.IsOn = Settings.Advanced.IsEnableUriScheme;
                 ToggleSwitchIsQuadIR.IsOn = Settings.Advanced.IsQuadIR;
                 ToggleSwitchEraserBindTouchMultiplier.IsOn = Settings.Advanced.EraserBindTouchMultiplier;
                 ToggleSwitchIsEnableFullScreenHelper.IsOn = Settings.Advanced.IsEnableFullScreenHelper;

--- a/Ink Canvas/MainWindow_cs/MW_UriHandler.cs
+++ b/Ink Canvas/MainWindow_cs/MW_UriHandler.cs
@@ -1,0 +1,77 @@
+using Ink_Canvas.Helpers;
+using System;
+using System.Windows;
+
+namespace Ink_Canvas
+{
+    public partial class MainWindow
+    {
+        public void HandleUriCommand(string uri)
+        {
+            try
+            {
+                if (string.IsNullOrEmpty(uri)) return;
+
+                LogHelper.WriteLogToFile($"正在处理URI命令: {uri}", LogHelper.LogType.Event);
+
+                // 解析URI
+                // 格式: icc://command?param=value
+                // 如果URI以icc:开头但不是标准URI格式，尝试手动解析
+                string command = "";
+                
+                if (Uri.TryCreate(uri, UriKind.Absolute, out Uri uriObj))
+                {
+                    command = uriObj.Host.ToLower();
+                }
+                else if (uri.StartsWith("icc:", StringComparison.OrdinalIgnoreCase))
+                {
+                    // 简单的手动解析: icc:fold
+                    string path = uri.Substring(4);
+                    // 移除可能的斜杠
+                    command = path.Trim('/').ToLower();
+                }
+
+                switch (command)
+                {
+                    case "fold":
+                        if (!isFloatingBarFolded)
+                        {
+                            FoldFloatingBar_MouseUp(new object(), null);
+                            ShowNotification("已进入收纳模式");
+                        }
+                        break;
+
+                    case "unfold":
+                    case "show": // 兼容旧习惯
+                        if (isFloatingBarFolded)
+                        {
+                            UnFoldFloatingBar_MouseUp(new object(), null);
+                            ShowNotification("已退出收纳模式");
+                        }
+                        break;
+                        
+                    case "toggle":
+                        if (isFloatingBarFolded)
+                        {
+                            UnFoldFloatingBar_MouseUp(new object(), null);
+                            ShowNotification("已退出收纳模式");
+                        }
+                        else
+                        {
+                            FoldFloatingBar_MouseUp(new object(), null);
+                            ShowNotification("已进入收纳模式");
+                        }
+                        break;
+
+                    default:
+                        LogHelper.WriteLogToFile($"未知的URI命令: {command}", LogHelper.LogType.Warning);
+                        break;
+                }
+            }
+            catch (Exception ex)
+            {
+                LogHelper.WriteLogToFile($"处理URI命令时出错: {ex.Message}", LogHelper.LogType.Error);
+            }
+        }
+    }
+}

--- a/Ink Canvas/Resources/Settings.cs
+++ b/Ink Canvas/Resources/Settings.cs
@@ -629,6 +629,9 @@ namespace Ink_Canvas
         [JsonProperty("enableUIAccessTopMost")]
         public bool EnableUIAccessTopMost { get; set; } = false;
 
+        [JsonProperty("isEnableUriScheme")]
+        public bool IsEnableUriScheme { get; set; } = false;
+
         [JsonProperty("windowMode")]
         public bool WindowMode { get; set; } = true;
     }

--- a/Ink Canvas/Windows/SettingsViews/SettingsViews/AdvancedPanel.xaml
+++ b/Ink Canvas/Windows/SettingsViews/SettingsViews/AdvancedPanel.xaml
@@ -430,10 +430,32 @@
                     <TextBlock Text="管理.icstk文件的关联设置，双击.icstk文件可直接在Ink Canvas中打开" 
                                TextWrapping="Wrap" Foreground="#9a9996" FontSize="11" Margin="0,0,0,12"/>
                     <StackPanel Orientation="Horizontal" HorizontalAlignment="Left" Margin="0,8,0,0">
-                        <Button x:Name="BtnUnregisterFileAssociation" Content="取消文件关联" Padding="15,5" Margin="0,0,8,0" Background="#2563eb" Foreground="White"/>
-                        <Button x:Name="BtnCheckFileAssociation" Content="检查关联状态" Padding="15,5" Margin="0,0,8,0" Background="#2563eb" Foreground="White"/>
-                        <Button x:Name="BtnRegisterFileAssociation" Content="重新注册关联" Padding="15,5" Background="#2563eb" Foreground="White"/>
+                        <Button x:Name="BtnUnregisterFileAssociation" Content="取消文件关联" Padding="15,5" Margin="0,0,8,0" Background="#2563eb" Foreground="White" Click="Button_Click"/>
+                        <Button x:Name="BtnCheckFileAssociation" Content="检查关联状态" Padding="15,5" Margin="0,0,8,0" Background="#2563eb" Foreground="White" Click="Button_Click"/>
+                        <Button x:Name="BtnRegisterFileAssociation" Content="重新注册关联" Padding="15,5" Background="#2563eb" Foreground="White" Click="Button_Click"/>
                     </StackPanel>
+                </StackPanel>
+            </Border>
+
+            <!-- 外部协议调用 -->
+            <Border Margin="0,25,0,0" BorderBrush="#e6e6e6" BorderThickness="1.25,1.25,1.25,4" CornerRadius="8">
+                <StackPanel Orientation="Vertical" Margin="18,18,18,18">
+                    <TextBlock Text="外部协议调用" FontWeight="Bold" Foreground="#2e3436" FontSize="18" Margin="0,0,0,12"/>
+                    <TextBlock Text="允许通过 icc:// 协议调用软件，支持从浏览器或其他应用快速控制软件" 
+                               TextWrapping="Wrap" Foreground="#9a9996" FontSize="11" Margin="0,0,0,12"/>
+                    <Grid Height="54">
+                        <StackPanel Orientation="Vertical" VerticalAlignment="Center" HorizontalAlignment="Left">
+                            <TextBlock Foreground="#2e3436" FontSize="14.5" Text="启用外部协议 (icc://)" HorizontalAlignment="Left"/>
+                            <TextBlock Foreground="#9a9996" FontSize="11" Margin="0,3.5,0,0" Text="开启后可通过 icc://fold (收纳) 或 icc://unfold (展开) 等命令控制" HorizontalAlignment="Left"/>
+                        </StackPanel>
+                        <Border x:Name="ToggleSwitchIsEnableUriScheme" Style="{StaticResource ToggleSwitchStyle}" Background="#3584e4" Tag="IsEnableUriScheme" MouseLeftButtonDown="ToggleSwitch_Click">
+                            <Border Width="19" Height="19" Background="White" CornerRadius="10" HorizontalAlignment="Right" VerticalAlignment="Center">
+                                <Border.Effect>
+                                    <DropShadowEffect BlurRadius="4" Direction="-45" Color="Black" Opacity="0.3" ShadowDepth="0"/>
+                                </Border.Effect>
+                            </Border>
+                        </Border>
+                    </Grid>
                 </StackPanel>
             </Border>
             

--- a/Ink Canvas/Windows/SettingsViews/SettingsViews/AdvancedPanel.xaml.cs
+++ b/Ink Canvas/Windows/SettingsViews/SettingsViews/AdvancedPanel.xaml.cs
@@ -141,6 +141,9 @@ namespace Ink_Canvas.Windows.SettingsViews
                 SetToggleSwitchState(FindToggleSwitch("ToggleSwitchIsAutoBackupEnabled"), advanced.IsAutoBackupEnabled);
                 SetOptionButtonState("AutoBackupInterval", advanced.AutoBackupIntervalDays);
 
+                // 外部协议
+                SetToggleSwitchState(FindToggleSwitch("ToggleSwitchIsEnableUriScheme"), advanced.IsEnableUriScheme);
+
                 // 悬浮窗拦截
                 // 注意：IsEnableFloatingWindowInterception 可能不在 Advanced 类中，需要确认
                 // 这里先假设它在 Advanced 类中，如果不在，需要调整
@@ -318,6 +321,11 @@ namespace Ink_Canvas.Windows.SettingsViews
                 case "IsAutoBackupEnabled":
                     // 调用 MainWindow 中的方法
                     MainWindowSettingsHelper.InvokeToggleSwitchToggled("ToggleSwitchIsAutoBackupEnabled", newState);
+                    break;
+
+                case "IsEnableUriScheme":
+                    // 调用 MainWindow 中的方法
+                    MainWindowSettingsHelper.InvokeToggleSwitchToggled("ToggleSwitchIsEnableUriScheme", newState);
                     break;
             }
         }

--- a/Ink Canvas/Windows/SettingsViews/SettingsViews/MainWindowSettingsHelper.cs
+++ b/Ink Canvas/Windows/SettingsViews/SettingsViews/MainWindowSettingsHelper.cs
@@ -446,6 +446,7 @@ namespace Ink_Canvas.Windows.SettingsViews
                 { "ToggleSwitchIsEnableResolutionChangeDetection", "AdvancedPanel" },
                 { "ToggleSwitchIsAutoBackupBeforeUpdate", "AdvancedPanel" },
                 { "ToggleSwitchIsAutoBackupEnabled", "AdvancedPanel" },
+                { "ToggleSwitchIsEnableUriScheme", "AdvancedPanel" },
                 
                 // LuckyRandomPanel
                 { "ToggleSwitchDisplayRandWindowNamesInputBtn", "LuckyRandomPanel" },


### PR DESCRIPTION
摘要 (Summary)
  本项目引入了自定义外部协议 icc:// 支持，允许其他程序（如自定义侧边栏、网页或快捷方式）通过 URI 远程控制 Ink
  Canvas。通过此功能，用户可以快速切换收纳状态或调用侧边栏工具（点名、计时器、白板等）。

  主要改动 (Key Changes)


  1. 协议注册与管理
   * 新增 `Helpers/UriSchemeHelper.cs`: 负责处理系统注册表的写入与注销。采用 HKEY_CURRENT_USER 路径，无需管理员权限即可启用。
   * 设置 UI: 在“高级选项”面板中增加了“启用外部协议 (icc://)”开关，并支持状态实时同步。


  2. 指令解析与执行
   * 新增 `MainWindow_cs/MW_UriHandler.cs`: 实现了 HandleUriCommand 方法，解析传入的 URI 路径。
   * 基础指令: 支持 fold (收起), unfold (展开), toggle (切换)。
   * 工具指令: 支持直接打开收纳模式下的工具：randone (单次抽), rand (随机抽), timer (计时器), whiteboard (白板)。


  3. 增强 IPC (进程间通信)
   * 多实例处理: 优化了 App.xaml.cs 的启动逻辑。当软件已在运行时，新的 URI 调用会通过
     IPC（基于系统事件和临时文件）将指令发送给已有的单实例处理，避免重复启动。
   * 启动参数: 即使软件未运行，启动时带有的 URI 参数也能被正确捕获并执行。


  4. 隐藏功能：收起时彻底隐藏
   * 新增设置项 `ThoroughlyHideWhenFolded`: 这是一个专为解决界面冲突设计的隐藏功能。
   * 逻辑实现: 开启后，进入收纳模式将直接隐藏主窗口 (Visibility = Hidden)，而非停留在屏幕边缘。可通过 icc://thoroughHideOn/Off 指令控制。

  5. 文档支持
   * 新增 `Docs/ExternalProtocol.md`: 详细记录了所有可用指令、调用方式及开发者说明。


  测试用例 (Test Cases)
   1. 设置测试: 在高级设置中开启开关，检查注册表 HKCU\Software\Classes\icc 是否正确生成。
   2. 运行调用: 在运行对话框 (Win+R) 输入 icc://timer，观察软件是否自动弹出计时器。
   3. 状态控制: 在展开状态下输入 icc://fold，验证墨迹是否清空并自动收纳。
   4. 彻底隐藏测试: 调用 icc://thoroughHideOn 后收起软件，确认主窗口不再占用屏幕边缘空间。
   
   
   
   ---
   
   
   ~~其实就是为了让我的 PANDAJSR/sidebar-for-class 能够方便的调用 ICC-CE 中的功能~~