### PR TITLE
Add debug logging and improve error handling for process protection and startup shortcut management

### DIFF
--- a/Ink Canvas/Helpers/ProcessProtectionManager.cs
+++ b/Ink Canvas/Helpers/ProcessProtectionManager.cs
@@ -23,6 +23,20 @@ namespace Ink_Canvas.Helpers
             "AutoUpdate"
         };
 
+        private static readonly string DebugTag = "[ProcessProtectionManager]";
+
+        private static void WriteDebugLog(string message, Exception ex = null)
+        {
+            if (ex == null)
+            {
+                System.Diagnostics.Debug.WriteLine($"{DebugTag} {message}");
+                return;
+            }
+
+            System.Diagnostics.Debug.WriteLine($"{DebugTag} {message}: {ex.Message}");
+        }
+
+
         public static bool Enabled
         {
             get { lock (_lock) return _enabled; }
@@ -70,7 +84,10 @@ namespace Ink_Canvas.Helpers
                     {
                         LogHelper.WriteLogToFile($"ProcessProtectionManager.SetEnabled 后台执行失败: {ex.Message}", LogHelper.LogType.Warning);
                     }
-                    catch { }
+                    catch (Exception logEx)
+                    {
+                        WriteDebugLog("写入告警日志失败", logEx);
+                    }
                 }
             });
         }
@@ -104,7 +121,7 @@ namespace Ink_Canvas.Helpers
                 }
                 catch (Exception ex)
                 {
-                    System.Diagnostics.Debug.WriteLine($"[ProcessProtectionManager] 写日志失败: {ex.Message}");
+                    WriteDebugLog("写日志失败", ex);
                 }
 
                 var normPath = NormalizePath(targetPath);
@@ -139,14 +156,14 @@ namespace Ink_Canvas.Helpers
                     {
                         foreach (var kv in fallbackFiles)
                         {
-                            try { kv.Value.Dispose(); } catch (Exception ex) { System.Diagnostics.Debug.WriteLine(ex); }
+                            try { kv.Value.Dispose(); } catch (Exception ex) { WriteDebugLog("释放文件锁失败", ex); }
                         }
                     }
                     if (fallbackDirs != null)
                     {
                         foreach (var kv in fallbackDirs)
                         {
-                            try { kv.Value.Dispose(); } catch (Exception ex) { System.Diagnostics.Debug.WriteLine(ex); }
+                            try { kv.Value.Dispose(); } catch (Exception ex) { WriteDebugLog("释放文件锁失败", ex); }
                         }
                     }
 
@@ -161,7 +178,7 @@ namespace Ink_Canvas.Helpers
                             Enable(rescanRoot: false, rescanDirs: dirsChain);
                         }
                     }
-                    catch { }
+                    catch (Exception ex) { WriteDebugLog("降级路径恢复保护失败", ex); }
                 }
                 return;
             }
@@ -199,14 +216,14 @@ namespace Ink_Canvas.Helpers
                 {
                     foreach (var kv in releasedFiles)
                     {
-                        try { kv.Value.Dispose(); } catch (Exception ex) { System.Diagnostics.Debug.WriteLine(ex); }
+                        try { kv.Value.Dispose(); } catch (Exception ex) { WriteDebugLog("释放文件锁失败", ex); }
                     }
                 }
                 if (releasedDirs != null)
                 {
                     foreach (var kv in releasedDirs)
                     {
-                        try { kv.Value.Dispose(); } catch (Exception ex) { System.Diagnostics.Debug.WriteLine(ex); }
+                        try { kv.Value.Dispose(); } catch (Exception ex) { WriteDebugLog("释放文件锁失败", ex); }
                     }
                 }
 
@@ -221,8 +238,9 @@ namespace Ink_Canvas.Helpers
                         Enable(rescanRoot: false, rescanDirs: dirsToToggle);
                     }
                 }
-                catch
+                catch (Exception ex)
                 {
+                    WriteDebugLog("恢复目录/文件保护失败", ex);
                 }
 
                 Interlocked.Exchange(ref _writeGate, 0);
@@ -305,8 +323,9 @@ namespace Ink_Canvas.Helpers
                     }
                 }
             }
-            catch
+            catch (Exception ex)
             {
+                WriteDebugLog("启用保护失败", ex);
             }
         }
 
@@ -323,13 +342,13 @@ namespace Ink_Canvas.Helpers
             {
                 foreach (var kv in _lockedFiles)
                 {
-                    try { kv.Value.Dispose(); } catch (Exception ex) { System.Diagnostics.Debug.WriteLine(ex); }
+                    try { kv.Value.Dispose(); } catch (Exception ex) { WriteDebugLog("释放文件锁失败", ex); }
                 }
                 _lockedFiles.Clear();
 
                 foreach (var kv in _lockedDirs)
                 {
-                    try { kv.Value.Dispose(); } catch (Exception ex) { System.Diagnostics.Debug.WriteLine(ex); }
+                    try { kv.Value.Dispose(); } catch (Exception ex) { WriteDebugLog("释放文件锁失败", ex); }
                 }
                 _lockedDirs.Clear();
             }
@@ -356,8 +375,9 @@ namespace Ink_Canvas.Helpers
                     }
                 }
             }
-            catch
+            catch (Exception ex)
             {
+                WriteDebugLog("遍历锁定对象时发生异常", ex);
             }
         }
 
@@ -388,8 +408,9 @@ namespace Ink_Canvas.Helpers
                     }
                 }
             }
-            catch
+            catch (Exception ex)
             {
+                WriteDebugLog("遍历锁定对象时发生异常", ex);
             }
         }
 
@@ -408,8 +429,9 @@ namespace Ink_Canvas.Helpers
                     var fs = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read);
                     _lockedFiles[filePath] = fs;
                 }
-                catch
+                catch (Exception ex)
                 {
+                    WriteDebugLog("锁定文件失败", ex);
                 }
             }
         }
@@ -432,8 +454,9 @@ namespace Ink_Canvas.Helpers
                         _lockedDirs[dirPath] = handle;
                     }
                 }
-                catch
+                catch (Exception ex)
                 {
+                    WriteDebugLog("锁定目录失败", ex);
                 }
             }
         }
@@ -450,8 +473,9 @@ namespace Ink_Canvas.Helpers
                 if (string.IsNullOrWhiteSpace(p)) return p;
                 return Path.GetFullPath(p.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
             }
-            catch
+            catch (Exception ex)
             {
+                WriteDebugLog("路径规范化失败", ex);
                 return p;
             }
         }
@@ -478,8 +502,9 @@ namespace Ink_Canvas.Helpers
                     dir = NormalizePath(Path.GetDirectoryName(dir));
                 }
             }
-            catch
+            catch (Exception ex)
             {
+                WriteDebugLog("构建目录链失败", ex);
             }
             return list;
         }
@@ -505,8 +530,9 @@ namespace Ink_Canvas.Helpers
                     }
                 }
             }
-            catch
+            catch (Exception ex)
             {
+                WriteDebugLog("排除路径检查失败", ex);
             }
             return false;
         }

--- a/Ink Canvas/MainWindow_cs/MW_AutoStart.cs
+++ b/Ink Canvas/MainWindow_cs/MW_AutoStart.cs
@@ -3,6 +3,7 @@ using System;
 using System.Windows;
 using Application = System.Windows.Forms.Application;
 using File = System.IO.File;
+using Path = System.IO.Path;
 
 namespace Ink_Canvas
 {
@@ -24,13 +25,29 @@ namespace Ink_Canvas
         /// 7. 保存快捷方式
         /// 8. 捕获可能的异常，确保方法不会因异常而崩溃
         /// </remarks>
+        private const string CurrentStartupShortcutName = "Ink Canvas Annotation";
+        private const string LegacyStartupShortcutName = "InkCanvas";
+
+        private static string GetStartupShortcutPath(string shortcutName)
+        {
+            return Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.Startup),
+                $"{shortcutName}.lnk");
+        }
+
+        public static bool IsAutoStartEnabled()
+        {
+            return File.Exists(GetStartupShortcutPath(CurrentStartupShortcutName)) ||
+                   File.Exists(GetStartupShortcutPath(LegacyStartupShortcutName));
+        }
+
         public static bool StartAutomaticallyCreate(string exeName)
         {
             try
             {
                 var shell = new WshShell();
-                var shortcut = (IWshShortcut)shell.CreateShortcut(
-                    Environment.GetFolderPath(Environment.SpecialFolder.Startup) + "\\" + exeName + ".lnk");
+                var startupShortcutPath = GetStartupShortcutPath(exeName);
+                var shortcut = (IWshShortcut)shell.CreateShortcut(startupShortcutPath);
                 //设置快捷方式的目标所在的位置(源程序完整路径)
                 shortcut.TargetPath = Application.ExecutablePath;
                 //应用程序的工作目录
@@ -45,7 +62,10 @@ namespace Ink_Canvas
                 shortcut.Save();
                 return true;
             }
-            catch (Exception) { }
+            catch (Exception ex)
+            {
+                Helpers.LogHelper.WriteLogToFile($"创建开机自启动快捷方式失败: {ex}", Helpers.LogHelper.LogType.Error);
+            }
 
             return false;
         }
@@ -64,11 +84,14 @@ namespace Ink_Canvas
         {
             try
             {
-                File.Delete(Environment.GetFolderPath(Environment.SpecialFolder.Startup) + "\\" + exeName +
-                            ".lnk");
+                var startupShortcutPath = GetStartupShortcutPath(exeName);
+                File.Delete(startupShortcutPath);
                 return true;
             }
-            catch (Exception) { }
+            catch (Exception ex)
+            {
+                Helpers.LogHelper.WriteLogToFile($"删除开机自启动快捷方式失败: {ex}", Helpers.LogHelper.LogType.Error);
+            }
 
             return false;
         }

--- a/Ink Canvas/MainWindow_cs/MW_SettingsToLoad.cs
+++ b/Ink Canvas/MainWindow_cs/MW_SettingsToLoad.cs
@@ -170,8 +170,9 @@ namespace Ink_Canvas
             {
                 ProcessProtectionManager.ApplyFromSettings();
             }
-            catch
+            catch (Exception ex)
             {
+                LogHelper.WriteLogToFile($"应用进程保护设置失败: {ex}", LogHelper.LogType.Warning);
             }
 
             // Startup
@@ -212,21 +213,14 @@ namespace Ink_Canvas
                     }
                 }
             }
-            catch
+            catch (Exception ex)
             {
+                LogHelper.WriteLogToFile($"加载遥测设置失败: {ex}", LogHelper.LogType.Warning);
             }
 
             try
             {
-                if (File.Exists(Environment.GetFolderPath(Environment.SpecialFolder.Startup) +
-                                "\\Ink Canvas Annotation.lnk"))
-                {
-                    ToggleSwitchRunAtStartup.IsOn = true;
-                }
-                else
-                {
-                    ToggleSwitchRunAtStartup.IsOn = false;
-                }
+                ToggleSwitchRunAtStartup.IsOn = IsAutoStartEnabled();
             }
             catch (Exception ex)
             {

--- a/Ink Canvas/Windows/SettingsViews/SettingsViews/StartupPanel.xaml.cs
+++ b/Ink Canvas/Windows/SettingsViews/SettingsViews/StartupPanel.xaml.cs
@@ -89,8 +89,7 @@ namespace Ink_Canvas.Windows.SettingsViews
                 if (toggleSwitchRunAtStartup != null)
                 {
                     // 检查启动项是否存在
-                    bool runAtStartup = System.IO.File.Exists(
-                        Environment.GetFolderPath(Environment.SpecialFolder.Startup) + "\\Ink Canvas Annotation.lnk");
+                    bool runAtStartup = MainWindow.IsAutoStartEnabled();
                     SetToggleSwitchState(toggleSwitchRunAtStartup, runAtStartup);
                 }
 
@@ -179,8 +178,7 @@ namespace Ink_Canvas.Windows.SettingsViews
                 {
                     case "RunAtStartup":
                         // 检查启动项是否存在
-                        return System.IO.File.Exists(
-                            Environment.GetFolderPath(Environment.SpecialFolder.Startup) + "\\Ink Canvas Annotation.lnk");
+                        return MainWindow.IsAutoStartEnabled();
                     case "FoldAtStartup":
                         return MainWindow.Settings.Startup?.IsFoldAtStartup ?? false;
                     case "NoFocusMode":
@@ -197,8 +195,9 @@ namespace Ink_Canvas.Windows.SettingsViews
                         return false;
                 }
             }
-            catch
+            catch (Exception ex)
             {
+                System.Diagnostics.Debug.WriteLine($"读取启动页设置值失败: {ex.Message}");
                 return false;
             }
         }


### PR DESCRIPTION
### Motivation
- Improve reliability and diagnosability of the process protection subsystem by surfacing swallowed exceptions and adding debug logging.
- Make startup shortcut handling more robust and support both current and legacy shortcut names.
- Centralize path/shortcut logic to avoid duplicated path concatenation and fragile string usage.

### Description
- Introduced a `DebugTag` and `WriteDebugLog` helper and replaced many empty `catch` blocks to log exceptions instead of silently swallowing them in `ProcessProtectionManager` and related code paths.
- Converted previously silent exception handlers to call `WriteDebugLog` with contextual messages for operations such as releasing locks, enabling/disabling protection, directory/file locking, path normalization, and directory chain construction.
- Added startup shortcut utilities in `MW_AutoStart.cs`: `GetStartupShortcutPath`, `IsAutoStartEnabled`, and constants `CurrentStartupShortcutName` and `LegacyStartupShortcutName`, and used `Path.Combine` consistently with a `Path` alias import.
- Made startup shortcut creation/deletion log failures via `Helpers.LogHelper` and updated UI/settings code to use `MainWindow.IsAutoStartEnabled()` in several places.

### Testing
- Built the solution using `msbuild` and the build completed successfully.
- Ran `dotnet test`, which discovered no unit tests in the repository (no test failures reported).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a79bd52b3c832c8e30c6407cfd1e4c)