### PR TITLE
撤销 commits bbe262d and 7d0de8b

### DIFF
--- a/Ink Canvas/App.xaml.cs
+++ b/Ink Canvas/App.xaml.cs
@@ -1195,7 +1195,6 @@ namespace Ink_Canvas
         private static DateTime startupCompleteHeartbeat = DateTime.MinValue;
         private static DateTime splashScreenStartTime = DateTime.MinValue;
         private static DateTime appStartupStartTime = DateTime.MinValue;
-        private static readonly TimeSpan StartupTimeout = TimeSpan.FromMinutes(2);
 
         /// <summary>
         /// 启动并管理应用的心跳与守护检查定时器，监测启动阶段与主线程是否无响应，并在符合配置的情况下尝试静默重启应用。
@@ -1219,8 +1218,6 @@ namespace Ink_Canvas
 
             watchdogTimer = new Timer(_ =>
             {
-                var now = DateTime.Now;
-
                 if (IsOobeShowing)
                     return;
 
@@ -1229,8 +1226,8 @@ namespace Ink_Canvas
                     DateTime startTime = _isSplashScreenShown && splashScreenStartTime != DateTime.MinValue
                         ? splashScreenStartTime
                         : appStartupStartTime;
-                    TimeSpan elapsedSinceStart = now - startTime;
-                    if (elapsedSinceStart >= StartupTimeout)
+                    TimeSpan elapsedSinceStart = DateTime.Now - startTime;
+                    if (elapsedSinceStart.TotalMinutes >= 2)
                     {
                         string timeType = _isSplashScreenShown ? "启动画面已显示" : "应用启动开始";
                         LogHelper.WriteLogToFile($"检测到启动假死：{timeType}{elapsedSinceStart.TotalMinutes:F2}分钟，但未收到启动完成心跳，自动重启。", LogHelper.LogType.Error);
@@ -1255,12 +1252,8 @@ namespace Ink_Canvas
                         return;
                     }
                 }
-
-                if (isStartupComplete && (now - lastHeartbeat).TotalSeconds > 10)
+                if (isStartupComplete && (DateTime.Now - lastHeartbeat).TotalSeconds > 10)
                 {
-                    if (appStartupStartTime != DateTime.MinValue && (now - appStartupStartTime) < StartupTimeout)
-                        return;
-
                     LogHelper.NewLog("检测到主线程无响应，自动重启。");
                     SyncCrashActionFromSettings();
                     if (CrashAction == CrashActionType.SilentRestart)

--- a/Ink Canvas/Helpers/PPTManager.cs
+++ b/Ink Canvas/Helpers/PPTManager.cs
@@ -338,61 +338,8 @@ namespace Ink_Canvas.Helpers
                     }
                 }, DispatcherPriority.Normal, CancellationToken.None, TimeSpan.FromSeconds(2));
 
-                // 初始化当前演示文稿信息
-                try
-                {
-                    var pres = GetCurrentActivePresentation();
-                    if (pres != null && Marshal.IsComObject(pres))
-                    {
-                        SafeReleaseComObject(CurrentPresentation, "CurrentPresentation");
-                        CurrentPresentation = pres;
-
-                        try
-                        {
-                            CurrentSlides = pres.Slides;
-                            try
-                            {
-                                var slideCount = CurrentSlides.Count;
-                                SlidesCount = slideCount > 0 ? slideCount : 0;
-                            }
-                            catch (COMException comEx)
-                            {
-                                var hr = (uint)comEx.HResult;
-                                SlidesCount = 0;
-                                if (!IsPptBusyHResult(hr) && hr != 0x8001010E && hr != 0x80004005 && hr != 0x80048240)
-                                {
-                                    LogHelper.WriteLogToFile($"读取PPT页数失败: {comEx.Message} (HR: 0x{hr:X8})", LogHelper.LogType.Warning);
-                                }
-                            }
-                        }
-                        catch (COMException comEx)
-                        {
-                            var hr = (uint)comEx.HResult;
-                            CurrentSlides = null;
-                            SlidesCount = 0;
-                            CurrentSlide = null;
-                            if (!IsPptBusyHResult(hr) && hr != 0x8001010E && hr != 0x80004005 && hr != 0x80048240)
-                            {
-                                LogHelper.WriteLogToFile($"初始化演示文稿信息失败: {comEx.Message} (HR: 0x{hr:X8})", LogHelper.LogType.Warning);
-                            }
-                        }
-                    }
-                    else
-                    {
-                        CurrentPresentation = null;
-                        CurrentSlides = null;
-                        CurrentSlide = null;
-                        SlidesCount = 0;
-                    }
-                }
-                catch (Exception ex)
-                {
-                    LogHelper.WriteLogToFile($"初始化演示文稿信息失败: {ex}", LogHelper.LogType.Warning);
-                    CurrentPresentation = null;
-                    CurrentSlides = null;
-                    CurrentSlide = null;
-                    SlidesCount = 0;
-                }
+                // 获取当前演示文稿信息
+                UpdateCurrentPresentationInfo();
 
                 // 触发连接成功事件
                 PPTConnectionChanged?.Invoke(true);
@@ -589,49 +536,135 @@ namespace Ink_Canvas.Helpers
                 LogHelper.WriteLogToFile($"释放COM对象 {objectName} 时发生异常: {ex}", LogHelper.LogType.Warning);
             }
         }
-        #endregion
 
-        #region Event Handlers
-        private void OnPresentationOpen(Presentation pres)
+        private void UpdateCurrentPresentationInfo()
         {
+            object activePresentation = null;
+            object slideShowWindows = null;
+            object slideShowWindow = null;
+            object activeWindow = null;
+            object view = null;
+            object selection = null;
+            object slideRange = null;
+            
             try
             {
-                if (pres != null && Marshal.IsComObject(pres))
+                if (PPTApplication != null && Marshal.IsComObject(PPTApplication))
                 {
-                    SafeReleaseComObject(CurrentPresentation, "CurrentPresentation");
-                    CurrentPresentation = pres;
-
                     try
                     {
-                        CurrentSlides = pres.Slides;
-                        try
+                        activePresentation = PPTApplication.ActivePresentation;
+                        if (activePresentation != null)
                         {
-                            var slideCount = CurrentSlides.Count;
-                            SlidesCount = slideCount > 0 ? slideCount : 0;
-                            if (slideCount == 0)
+                            SafeReleaseComObject(CurrentPresentation, "CurrentPresentation");
+                            CurrentPresentation = activePresentation as Presentation;
+                            CurrentSlides = CurrentPresentation.Slides;
+
+                            try
                             {
-                                LogHelper.WriteLogToFile("PPT演示文稿页数为0，可能为空演示文稿", LogHelper.LogType.Warning);
+                                var slideCount = CurrentSlides.Count;
+                                if (slideCount > 0)
+                                {
+                                    SlidesCount = slideCount;
+                                }
+                                else
+                                {
+                                    SlidesCount = 0;
+                                    LogHelper.WriteLogToFile("PPT演示文稿页数为0，可能为空演示文稿", LogHelper.LogType.Warning);
+                                }
                             }
-                        }
-                        catch (COMException comEx)
-                        {
-                            var hr = (uint)comEx.HResult;
-                            SlidesCount = 0;
-                            if (!IsPptBusyHResult(hr) && hr != 0x8001010E && hr != 0x80004005 && hr != 0x80048240)
+                            catch (COMException comEx)
                             {
+                                var hr = (uint)comEx.HResult;
+                                SlidesCount = 0;
                                 LogHelper.WriteLogToFile($"读取PPT页数失败: {comEx.Message} (HR: 0x{hr:X8})", LogHelper.LogType.Warning);
                             }
+
+                            try
+                            {
+                                slideShowWindows = PPTApplication.SlideShowWindows;
+                                if (IsInSlideShow && slideShowWindows != null)
+                                {
+                                    dynamic ssw = slideShowWindows;
+                                    if (ssw.Count > 0)
+                                    {
+                                        slideShowWindow = ssw[1];
+                                        if (slideShowWindow != null)
+                                        {
+                                            dynamic sswObj = slideShowWindow;
+                                            view = sswObj.View;
+                                            if (view != null)
+                                            {
+                                                dynamic viewObj = view;
+                                            CurrentSlide = viewObj.Slide as Slide;
+                                            }
+                                        }
+                                    }
+                                }
+                                else
+                                {
+                                    activeWindow = PPTApplication.ActiveWindow;
+                                    if (activeWindow != null)
+                                    {
+                                        dynamic aw = activeWindow;
+                                        selection = aw.Selection;
+                                        if (selection != null)
+                                        {
+                                            dynamic sel = selection;
+                                            slideRange = sel.SlideRange;
+                                            if (slideRange != null)
+                                            {
+                                                dynamic sr = slideRange;
+                                                int slideNumber = sr.SlideNumber;
+                                                if (slideNumber > 0 && slideNumber <= SlidesCount)
+                                                {
+                                                    CurrentSlide = CurrentSlides[slideNumber];
+                                                }
+                                            }
+                                        }
+                                    }
+                                    
+                                    if (CurrentSlide == null && SlidesCount > 0)
+                                    {
+                                        CurrentSlide = CurrentSlides[1];
+                                    }
+                                }
+                            }
+                            catch (COMException comEx)
+                            {
+                                var hr = (uint)comEx.HResult;
+                                if (hr != 0x8001010E && hr != 0x80004005)
+                                {
+                                    LogHelper.WriteLogToFile($"获取当前幻灯片失败: {comEx.Message}", LogHelper.LogType.Warning);
+                                }
+
+                                if (SlidesCount > 0)
+                                {
+                                    CurrentSlide = CurrentSlides[1];
+                                }
+                            }
+                        }
+                        else
+                        {
+                            CurrentPresentation = null;
+                            CurrentSlides = null;
+                            CurrentSlide = null;
+                            SlidesCount = 0;
                         }
                     }
                     catch (COMException comEx)
                     {
                         var hr = (uint)comEx.HResult;
-                        CurrentSlides = null;
-                        SlidesCount = 0;
-                        CurrentSlide = null;
-                        if (!IsPptBusyHResult(hr) && hr != 0x8001010E && hr != 0x80004005 && hr != 0x80048240)
+                        if (hr == 0x8001010E || hr == 0x80004005)
                         {
-                            LogHelper.WriteLogToFile($"初始化演示文稿信息失败: {comEx.Message} (HR: 0x{hr:X8})", LogHelper.LogType.Warning);
+                            CurrentPresentation = null;
+                            CurrentSlides = null;
+                            CurrentSlide = null;
+                            SlidesCount = 0;
+                        }
+                        else
+                        {
+                            LogHelper.WriteLogToFile($"访问活动演示文稿失败: {comEx}", LogHelper.LogType.Warning);
                         }
                     }
                 }
@@ -642,7 +675,37 @@ namespace Ink_Canvas.Helpers
                     CurrentSlide = null;
                     SlidesCount = 0;
                 }
+            }
+            catch (Exception ex)
+            {
+                LogHelper.WriteLogToFile($"更新演示文稿信息失败: {ex}", LogHelper.LogType.Error);
+                CurrentPresentation = null;
+                CurrentSlides = null;
+                CurrentSlide = null;
+                SlidesCount = 0;
+            }
+            finally
+            {
+                SafeReleaseComObject(slideRange);
+                SafeReleaseComObject(selection);
+                SafeReleaseComObject(view);
+                SafeReleaseComObject(slideShowWindow);
+                SafeReleaseComObject(activeWindow);
+                SafeReleaseComObject(slideShowWindows);
+                if (activePresentation != null && !ReferenceEquals(activePresentation, CurrentPresentation))
+                {
+                    SafeReleaseComObject(activePresentation);
+                }
+            }
+        }
+        #endregion
 
+        #region Event Handlers
+        private void OnPresentationOpen(Presentation pres)
+        {
+            try
+            {
+                UpdateCurrentPresentationInfo();
                 PresentationOpen?.Invoke(pres);
                 LogHelper.WriteLogToFile($"演示文稿已打开: {pres?.Name}", LogHelper.LogType.Event);
             }
@@ -671,67 +734,7 @@ namespace Ink_Canvas.Helpers
             _cachedIsInSlideShow = true;
             try
             {
-                try
-                {
-                    if (wn != null)
-                    {
-                        dynamic w = wn;
-                        var view = w.View;
-                        if (view != null)
-                        {
-                            var slide = view.Slide as Slide;
-                            if (slide != null)
-                            {
-                                CurrentSlide = slide;
-
-                                var pres = slide.Parent as Presentation;
-                                if (pres != null && Marshal.IsComObject(pres))
-                                {
-                                    SafeReleaseComObject(CurrentPresentation, "CurrentPresentation");
-                                    CurrentPresentation = pres;
-
-                                    try
-                                    {
-                                        CurrentSlides = pres.Slides;
-                                        try
-                                        {
-                                            var slideCount = CurrentSlides.Count;
-                                            SlidesCount = slideCount > 0 ? slideCount : 0;
-                                        }
-                                        catch (COMException comEx)
-                                        {
-                                            var hr = (uint)comEx.HResult;
-                                            SlidesCount = 0;
-                                            if (!IsPptBusyHResult(hr) && hr != 0x8001010E && hr != 0x80004005 && hr != 0x80048240)
-                                            {
-                                                LogHelper.WriteLogToFile($"读取PPT页数失败: {comEx.Message} (HR: 0x{hr:X8})", LogHelper.LogType.Warning);
-                                            }
-                                        }
-                                    }
-                                    catch (COMException comEx)
-                                    {
-                                        var hr = (uint)comEx.HResult;
-                                        CurrentSlides = null;
-                                        SlidesCount = 0;
-                                        if (!IsPptBusyHResult(hr) && hr != 0x8001010E && hr != 0x80004005 && hr != 0x80048240)
-                                        {
-                                            LogHelper.WriteLogToFile($"初始化演示文稿信息失败: {comEx.Message} (HR: 0x{hr:X8})", LogHelper.LogType.Warning);
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-                catch (COMException comEx)
-                {
-                    var hr = (uint)comEx.HResult;
-                    if (!IsPptBusyHResult(hr) && hr != 0x8001010E && hr != 0x80004005 && hr != 0x80048240)
-                    {
-                        LogHelper.WriteLogToFile($"更新放映开始时的演示文稿信息失败: {comEx.Message} (HR: 0x{hr:X8})", LogHelper.LogType.Warning);
-                    }
-                }
-
+                UpdateCurrentPresentationInfo();
                 SlideShowBegin?.Invoke(wn);
             }
             catch (Exception ex)
@@ -744,31 +747,7 @@ namespace Ink_Canvas.Helpers
         {
             try
             {
-                try
-                {
-                    if (wn != null)
-                    {
-                        dynamic w = wn;
-                        var view = w.View;
-                        if (view != null)
-                        {
-                            var slide = view.Slide as Slide;
-                            if (slide != null)
-                            {
-                                CurrentSlide = slide;
-                            }
-                        }
-                    }
-                }
-                catch (COMException comEx)
-                {
-                    var hr = (uint)comEx.HResult;
-                    if (!IsPptBusyHResult(hr) && hr != 0x8001010E && hr != 0x80004005 && hr != 0x80048240)
-                    {
-                        LogHelper.WriteLogToFile($"更新当前幻灯片失败: {comEx.Message} (HR: 0x{hr:X8})", LogHelper.LogType.Warning);
-                    }
-                }
-
+                UpdateCurrentPresentationInfo();
                 SlideShowNextSlide?.Invoke(wn);
             }
             catch (Exception ex)


### PR DESCRIPTION
### Motivation
- Remove two recent changes that introduced PPT-module adjustments and a watchdog/restart change by reverting commits `bbe262df7e0fdd766658c4b90fbbbcb1fbff6d82` and `7d0de8b5a3728825e1fc8dc6fb84c649725417df` to restore the previous, stable behavior.
- Resolve a merge conflict encountered while reverting to ensure the application watchdog logic remains consistent and safe.

### Description
- Created two revert commits on branch `work`: revert of `bbe262df7e0fdd766658c4b90fbbbcb1fbff6d82` (recorded as `fc4415b`) and revert of `7d0de8b5a3728825e1fc8dc6fb84c649725417df` (recorded as `938cce1`).
- Resolved a conflict in `Ink Canvas/App.xaml.cs` by removing conflict markers and keeping the `DateTime.Now`-based watchdog checks and the inline startup timeout check (`elapsedSinceStart.TotalMinutes >= 2`).
- Restored PPT manager behavior by reverting changes in `Ink Canvas/Helpers/PPTManager.cs` and introducing `UpdateCurrentPresentationInfo()` to centralize and harden retrieval of current presentation/slide state and COM cleanup.
- Files changed: `Ink Canvas/App.xaml.cs` and `Ink Canvas/Helpers/PPTManager.cs` (revert commits updated those files and removed leftover conflict markers).

### Testing
- Ran `git status --short` and confirmed working tree is clean and no uncommitted changes remain (success).
- Inspected history with `git log --oneline -n 5` to confirm the two revert commits are present on `work` (success).
- Verified revert results and touched files with `git show --stat --name-only` and validated that `Ink Canvas/App.xaml.cs` and `Ink Canvas/Helpers/PPTManager.cs` reflect the intended revert changes (success).
- Searched for leftover conflict markers with `rg -n "^(<<<<<<<|=======|>>>>>>>)"` in the modified files and confirmed none remain (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a8f79dafcc832cb914afbf11457bb7)