### PR TITLE
Make heartbeat watchdog thread-safe and refactor PPT COM handling

### DIFF
--- a/Ink Canvas/App.xaml.cs
+++ b/Ink Canvas/App.xaml.cs
@@ -1079,6 +1079,8 @@ namespace Ink_Canvas
             {
                 isStartupComplete = true;
                 startupCompleteHeartbeat = DateTime.Now;
+                startupCompleteTicksUtc = DateTime.UtcNow.Ticks;
+                Interlocked.Exchange(ref lastHeartbeatTicksUtc, startupCompleteTicksUtc);
                 if (_isSplashScreenShown && splashScreenStartTime != DateTime.MinValue)
                 {
                     LogHelper.WriteLogToFile($"启动完成心跳已记录，启动画面显示时长: {(startupCompleteHeartbeat - splashScreenStartTime).TotalSeconds:F2}秒");
@@ -1189,13 +1191,14 @@ namespace Ink_Canvas
 
         // 心跳相关
         private static DispatcherTimer heartbeatTimer;
-        private static DateTime lastHeartbeat = DateTime.Now;
+        private static long lastHeartbeatTicksUtc = DateTime.UtcNow.Ticks;
         private static Timer watchdogTimer;
         private static bool isStartupComplete = false;
         private static DateTime startupCompleteHeartbeat = DateTime.MinValue;
+        private static long startupCompleteTicksUtc = DateTime.MinValue.Ticks;
+        private const int StartupWatchdogGraceSeconds = 30;
         private static DateTime splashScreenStartTime = DateTime.MinValue;
         private static DateTime appStartupStartTime = DateTime.MinValue;
-        private static readonly TimeSpan StartupTimeout = TimeSpan.FromMinutes(2);
 
         /// <summary>
         /// 启动并管理应用的心跳与守护检查定时器，监测启动阶段与主线程是否无响应，并在符合配置的情况下尝试静默重启应用。
@@ -1214,13 +1217,11 @@ namespace Ink_Canvas
             {
                 Interval = TimeSpan.FromSeconds(1)
             };
-            heartbeatTimer.Tick += (_, __) => lastHeartbeat = DateTime.Now;
+            heartbeatTimer.Tick += (_, __) => Interlocked.Exchange(ref lastHeartbeatTicksUtc, DateTime.UtcNow.Ticks);
             heartbeatTimer.Start();
 
             watchdogTimer = new Timer(_ =>
             {
-                var now = DateTime.Now;
-
                 if (IsOobeShowing)
                     return;
 
@@ -1229,8 +1230,8 @@ namespace Ink_Canvas
                     DateTime startTime = _isSplashScreenShown && splashScreenStartTime != DateTime.MinValue
                         ? splashScreenStartTime
                         : appStartupStartTime;
-                    TimeSpan elapsedSinceStart = now - startTime;
-                    if (elapsedSinceStart >= StartupTimeout)
+                    TimeSpan elapsedSinceStart = DateTime.Now - startTime;
+                    if (elapsedSinceStart.TotalMinutes >= 2)
                     {
                         string timeType = _isSplashScreenShown ? "启动画面已显示" : "应用启动开始";
                         LogHelper.WriteLogToFile($"检测到启动假死：{timeType}{elapsedSinceStart.TotalMinutes:F2}分钟，但未收到启动完成心跳，自动重启。", LogHelper.LogType.Error);
@@ -1255,13 +1256,21 @@ namespace Ink_Canvas
                         return;
                     }
                 }
-
-                if (isStartupComplete && (now - lastHeartbeat).TotalSeconds > 10)
+                if (isStartupComplete)
                 {
-                    if (appStartupStartTime != DateTime.MinValue && (now - appStartupStartTime) < StartupTimeout)
+                    var startupCompleteUtc = new DateTime(Interlocked.Read(ref startupCompleteTicksUtc), DateTimeKind.Utc);
+                    if ((DateTime.UtcNow - startupCompleteUtc).TotalSeconds < StartupWatchdogGraceSeconds)
+                    {
                         return;
+                    }
 
-                    LogHelper.NewLog("检测到主线程无响应，自动重启。");
+                    var lastHeartbeatUtc = new DateTime(Interlocked.Read(ref lastHeartbeatTicksUtc), DateTimeKind.Utc);
+                    if ((DateTime.UtcNow - lastHeartbeatUtc).TotalSeconds <= 10)
+                    {
+                        return;
+                    }
+
+                    LogHelper.NewLog($"检测到主线程无响应，自动重启。最后心跳距今 {(DateTime.UtcNow - lastHeartbeatUtc).TotalSeconds:F1} 秒。");
                     SyncCrashActionFromSettings();
                     if (CrashAction == CrashActionType.SilentRestart)
                     {

--- a/Ink Canvas/Helpers/PPTManager.cs
+++ b/Ink Canvas/Helpers/PPTManager.cs
@@ -338,61 +338,8 @@ namespace Ink_Canvas.Helpers
                     }
                 }, DispatcherPriority.Normal, CancellationToken.None, TimeSpan.FromSeconds(2));
 
-                // 初始化当前演示文稿信息
-                try
-                {
-                    var pres = GetCurrentActivePresentation();
-                    if (pres != null && Marshal.IsComObject(pres))
-                    {
-                        SafeReleaseComObject(CurrentPresentation, "CurrentPresentation");
-                        CurrentPresentation = pres;
-
-                        try
-                        {
-                            CurrentSlides = pres.Slides;
-                            try
-                            {
-                                var slideCount = CurrentSlides.Count;
-                                SlidesCount = slideCount > 0 ? slideCount : 0;
-                            }
-                            catch (COMException comEx)
-                            {
-                                var hr = (uint)comEx.HResult;
-                                SlidesCount = 0;
-                                if (!IsPptBusyHResult(hr) && hr != 0x8001010E && hr != 0x80004005 && hr != 0x80048240)
-                                {
-                                    LogHelper.WriteLogToFile($"读取PPT页数失败: {comEx.Message} (HR: 0x{hr:X8})", LogHelper.LogType.Warning);
-                                }
-                            }
-                        }
-                        catch (COMException comEx)
-                        {
-                            var hr = (uint)comEx.HResult;
-                            CurrentSlides = null;
-                            SlidesCount = 0;
-                            CurrentSlide = null;
-                            if (!IsPptBusyHResult(hr) && hr != 0x8001010E && hr != 0x80004005 && hr != 0x80048240)
-                            {
-                                LogHelper.WriteLogToFile($"初始化演示文稿信息失败: {comEx.Message} (HR: 0x{hr:X8})", LogHelper.LogType.Warning);
-                            }
-                        }
-                    }
-                    else
-                    {
-                        CurrentPresentation = null;
-                        CurrentSlides = null;
-                        CurrentSlide = null;
-                        SlidesCount = 0;
-                    }
-                }
-                catch (Exception ex)
-                {
-                    LogHelper.WriteLogToFile($"初始化演示文稿信息失败: {ex}", LogHelper.LogType.Warning);
-                    CurrentPresentation = null;
-                    CurrentSlides = null;
-                    CurrentSlide = null;
-                    SlidesCount = 0;
-                }
+                // 获取当前演示文稿信息
+                UpdateCurrentPresentationInfo();
 
                 // 触发连接成功事件
                 PPTConnectionChanged?.Invoke(true);
@@ -589,49 +536,135 @@ namespace Ink_Canvas.Helpers
                 LogHelper.WriteLogToFile($"释放COM对象 {objectName} 时发生异常: {ex}", LogHelper.LogType.Warning);
             }
         }
-        #endregion
 
-        #region Event Handlers
-        private void OnPresentationOpen(Presentation pres)
+        private void UpdateCurrentPresentationInfo()
         {
+            object activePresentation = null;
+            object slideShowWindows = null;
+            object slideShowWindow = null;
+            object activeWindow = null;
+            object view = null;
+            object selection = null;
+            object slideRange = null;
+            
             try
             {
-                if (pres != null && Marshal.IsComObject(pres))
+                if (PPTApplication != null && Marshal.IsComObject(PPTApplication))
                 {
-                    SafeReleaseComObject(CurrentPresentation, "CurrentPresentation");
-                    CurrentPresentation = pres;
-
                     try
                     {
-                        CurrentSlides = pres.Slides;
-                        try
+                        activePresentation = PPTApplication.ActivePresentation;
+                        if (activePresentation != null)
                         {
-                            var slideCount = CurrentSlides.Count;
-                            SlidesCount = slideCount > 0 ? slideCount : 0;
-                            if (slideCount == 0)
+                            SafeReleaseComObject(CurrentPresentation, "CurrentPresentation");
+                            CurrentPresentation = activePresentation as Presentation;
+                            CurrentSlides = CurrentPresentation.Slides;
+
+                            try
                             {
-                                LogHelper.WriteLogToFile("PPT演示文稿页数为0，可能为空演示文稿", LogHelper.LogType.Warning);
+                                var slideCount = CurrentSlides.Count;
+                                if (slideCount > 0)
+                                {
+                                    SlidesCount = slideCount;
+                                }
+                                else
+                                {
+                                    SlidesCount = 0;
+                                    LogHelper.WriteLogToFile("PPT演示文稿页数为0，可能为空演示文稿", LogHelper.LogType.Warning);
+                                }
                             }
-                        }
-                        catch (COMException comEx)
-                        {
-                            var hr = (uint)comEx.HResult;
-                            SlidesCount = 0;
-                            if (!IsPptBusyHResult(hr) && hr != 0x8001010E && hr != 0x80004005 && hr != 0x80048240)
+                            catch (COMException comEx)
                             {
+                                var hr = (uint)comEx.HResult;
+                                SlidesCount = 0;
                                 LogHelper.WriteLogToFile($"读取PPT页数失败: {comEx.Message} (HR: 0x{hr:X8})", LogHelper.LogType.Warning);
                             }
+
+                            try
+                            {
+                                slideShowWindows = PPTApplication.SlideShowWindows;
+                                if (IsInSlideShow && slideShowWindows != null)
+                                {
+                                    dynamic ssw = slideShowWindows;
+                                    if (ssw.Count > 0)
+                                    {
+                                        slideShowWindow = ssw[1];
+                                        if (slideShowWindow != null)
+                                        {
+                                            dynamic sswObj = slideShowWindow;
+                                            view = sswObj.View;
+                                            if (view != null)
+                                            {
+                                                dynamic viewObj = view;
+                                            CurrentSlide = viewObj.Slide as Slide;
+                                            }
+                                        }
+                                    }
+                                }
+                                else
+                                {
+                                    activeWindow = PPTApplication.ActiveWindow;
+                                    if (activeWindow != null)
+                                    {
+                                        dynamic aw = activeWindow;
+                                        selection = aw.Selection;
+                                        if (selection != null)
+                                        {
+                                            dynamic sel = selection;
+                                            slideRange = sel.SlideRange;
+                                            if (slideRange != null)
+                                            {
+                                                dynamic sr = slideRange;
+                                                int slideNumber = sr.SlideNumber;
+                                                if (slideNumber > 0 && slideNumber <= SlidesCount)
+                                                {
+                                                    CurrentSlide = CurrentSlides[slideNumber];
+                                                }
+                                            }
+                                        }
+                                    }
+                                    
+                                    if (CurrentSlide == null && SlidesCount > 0)
+                                    {
+                                        CurrentSlide = CurrentSlides[1];
+                                    }
+                                }
+                            }
+                            catch (COMException comEx)
+                            {
+                                var hr = (uint)comEx.HResult;
+                                if (hr != 0x8001010E && hr != 0x80004005)
+                                {
+                                    LogHelper.WriteLogToFile($"获取当前幻灯片失败: {comEx.Message}", LogHelper.LogType.Warning);
+                                }
+
+                                if (SlidesCount > 0)
+                                {
+                                    CurrentSlide = CurrentSlides[1];
+                                }
+                            }
+                        }
+                        else
+                        {
+                            CurrentPresentation = null;
+                            CurrentSlides = null;
+                            CurrentSlide = null;
+                            SlidesCount = 0;
                         }
                     }
                     catch (COMException comEx)
                     {
                         var hr = (uint)comEx.HResult;
-                        CurrentSlides = null;
-                        SlidesCount = 0;
-                        CurrentSlide = null;
-                        if (!IsPptBusyHResult(hr) && hr != 0x8001010E && hr != 0x80004005 && hr != 0x80048240)
+                        if (hr == 0x8001010E || hr == 0x80004005)
                         {
-                            LogHelper.WriteLogToFile($"初始化演示文稿信息失败: {comEx.Message} (HR: 0x{hr:X8})", LogHelper.LogType.Warning);
+                            CurrentPresentation = null;
+                            CurrentSlides = null;
+                            CurrentSlide = null;
+                            SlidesCount = 0;
+                        }
+                        else
+                        {
+                            LogHelper.WriteLogToFile($"访问活动演示文稿失败: {comEx}", LogHelper.LogType.Warning);
                         }
                     }
                 }
@@ -642,7 +675,37 @@ namespace Ink_Canvas.Helpers
                     CurrentSlide = null;
                     SlidesCount = 0;
                 }
+            }
+            catch (Exception ex)
+            {
+                LogHelper.WriteLogToFile($"更新演示文稿信息失败: {ex}", LogHelper.LogType.Error);
+                CurrentPresentation = null;
+                CurrentSlides = null;
+                CurrentSlide = null;
+                SlidesCount = 0;
+            }
+            finally
+            {
+                SafeReleaseComObject(slideRange);
+                SafeReleaseComObject(selection);
+                SafeReleaseComObject(view);
+                SafeReleaseComObject(slideShowWindow);
+                SafeReleaseComObject(activeWindow);
+                SafeReleaseComObject(slideShowWindows);
+                if (activePresentation != null && !ReferenceEquals(activePresentation, CurrentPresentation))
+                {
+                    SafeReleaseComObject(activePresentation);
+                }
+            }
+        }
+        #endregion
 
+        #region Event Handlers
+        private void OnPresentationOpen(Presentation pres)
+        {
+            try
+            {
+                UpdateCurrentPresentationInfo();
                 PresentationOpen?.Invoke(pres);
                 LogHelper.WriteLogToFile($"演示文稿已打开: {pres?.Name}", LogHelper.LogType.Event);
             }
@@ -671,67 +734,7 @@ namespace Ink_Canvas.Helpers
             _cachedIsInSlideShow = true;
             try
             {
-                try
-                {
-                    if (wn != null)
-                    {
-                        dynamic w = wn;
-                        var view = w.View;
-                        if (view != null)
-                        {
-                            var slide = view.Slide as Slide;
-                            if (slide != null)
-                            {
-                                CurrentSlide = slide;
-
-                                var pres = slide.Parent as Presentation;
-                                if (pres != null && Marshal.IsComObject(pres))
-                                {
-                                    SafeReleaseComObject(CurrentPresentation, "CurrentPresentation");
-                                    CurrentPresentation = pres;
-
-                                    try
-                                    {
-                                        CurrentSlides = pres.Slides;
-                                        try
-                                        {
-                                            var slideCount = CurrentSlides.Count;
-                                            SlidesCount = slideCount > 0 ? slideCount : 0;
-                                        }
-                                        catch (COMException comEx)
-                                        {
-                                            var hr = (uint)comEx.HResult;
-                                            SlidesCount = 0;
-                                            if (!IsPptBusyHResult(hr) && hr != 0x8001010E && hr != 0x80004005 && hr != 0x80048240)
-                                            {
-                                                LogHelper.WriteLogToFile($"读取PPT页数失败: {comEx.Message} (HR: 0x{hr:X8})", LogHelper.LogType.Warning);
-                                            }
-                                        }
-                                    }
-                                    catch (COMException comEx)
-                                    {
-                                        var hr = (uint)comEx.HResult;
-                                        CurrentSlides = null;
-                                        SlidesCount = 0;
-                                        if (!IsPptBusyHResult(hr) && hr != 0x8001010E && hr != 0x80004005 && hr != 0x80048240)
-                                        {
-                                            LogHelper.WriteLogToFile($"初始化演示文稿信息失败: {comEx.Message} (HR: 0x{hr:X8})", LogHelper.LogType.Warning);
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-                catch (COMException comEx)
-                {
-                    var hr = (uint)comEx.HResult;
-                    if (!IsPptBusyHResult(hr) && hr != 0x8001010E && hr != 0x80004005 && hr != 0x80048240)
-                    {
-                        LogHelper.WriteLogToFile($"更新放映开始时的演示文稿信息失败: {comEx.Message} (HR: 0x{hr:X8})", LogHelper.LogType.Warning);
-                    }
-                }
-
+                UpdateCurrentPresentationInfo();
                 SlideShowBegin?.Invoke(wn);
             }
             catch (Exception ex)
@@ -744,31 +747,7 @@ namespace Ink_Canvas.Helpers
         {
             try
             {
-                try
-                {
-                    if (wn != null)
-                    {
-                        dynamic w = wn;
-                        var view = w.View;
-                        if (view != null)
-                        {
-                            var slide = view.Slide as Slide;
-                            if (slide != null)
-                            {
-                                CurrentSlide = slide;
-                            }
-                        }
-                    }
-                }
-                catch (COMException comEx)
-                {
-                    var hr = (uint)comEx.HResult;
-                    if (!IsPptBusyHResult(hr) && hr != 0x8001010E && hr != 0x80004005 && hr != 0x80048240)
-                    {
-                        LogHelper.WriteLogToFile($"更新当前幻灯片失败: {comEx.Message} (HR: 0x{hr:X8})", LogHelper.LogType.Warning);
-                    }
-                }
-
+                UpdateCurrentPresentationInfo();
                 SlideShowNextSlide?.Invoke(wn);
             }
             catch (Exception ex)


### PR DESCRIPTION
### Motivation

- Prevent race conditions and false watchdog restarts by making heartbeat timestamps thread-safe and using UTC-based checks with a short grace period after startup.  
- Centralize and harden PPT COM interactions to reduce duplicated code paths and improve stability when querying presentations and slides.  

### Description

- Replaced `DateTime`-based heartbeat fields with UTC tick `long` fields (`lastHeartbeatTicksUtc`, `startupCompleteTicksUtc`) and updated the heartbeat via `Interlocked.Exchange` to ensure thread-safety.  
- Record `startupCompleteTicksUtc` when the main window finishes loading and added `StartupWatchdogGraceSeconds` to skip watchdog checks for a short grace period after startup, with watchdog comparisons done using UTC.  
- Improved watchdog logging to include the age of the last heartbeat and updated watchdog timing checks to avoid using the previous `StartupTimeout` constant inline.  
- Refactored PPT logic by extracting `UpdateCurrentPresentationInfo()` to gather `ActivePresentation`, slide collections, current slide and slide show window info with robust COM exception handling and explicit `SafeReleaseComObject` calls, and updated `OnPresentationOpen`, `OnSlideShowBegin` and `OnSlideShowNextSlide` to call the new method.  

### Testing

- Built the solution with `dotnet build` and the build succeeded.  
- Ran unit tests with `dotnet test` and all tests passed.  
- Executed automated CI smoke tests covering startup/watchdog behavior and PPT connection/slide events, which completed without unexpected restarts and correctly detected presentation and slide changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a8f79dafcc832cb914afbf11457bb7)