### PR TITLE
fix: stabilize PPT slideshow state sync on transient COM states

### DIFF
--- a/Ink Canvas/Helpers/PPTManager.cs
+++ b/Ink Canvas/Helpers/PPTManager.cs
@@ -67,6 +67,7 @@ namespace Ink_Canvas.Helpers
         private readonly object _lockObject = new object();
         private bool _disposed;
         private static bool IsPptBusyHResult(uint hr) => hr == 0x80010001 || hr == 0x8001010A;
+        private static bool IsNoActivePresentationOrWindowHResult(uint hr) => hr == 0x80048240;
         #endregion
 
         #region Constructor & Initialization
@@ -537,7 +538,7 @@ namespace Ink_Canvas.Helpers
             }
         }
 
-        private void UpdateCurrentPresentationInfo()
+        private void UpdateCurrentPresentationInfo(bool preferSlideShowWindow = false, SlideShowWindow knownSlideShowWindow = null)
         {
             object activePresentation = null;
             object slideShowWindows = null;
@@ -553,7 +554,7 @@ namespace Ink_Canvas.Helpers
                 {
                     try
                     {
-                        activePresentation = PPTApplication.ActivePresentation;
+                        activePresentation = TryGetActivePresentation(knownSlideShowWindow);
                         if (activePresentation != null)
                         {
                             SafeReleaseComObject(CurrentPresentation, "CurrentPresentation");
@@ -583,21 +584,30 @@ namespace Ink_Canvas.Helpers
                             try
                             {
                                 slideShowWindows = PPTApplication.SlideShowWindows;
-                                if (IsInSlideShow && slideShowWindows != null)
+                                var shouldUseSlideShowWindow = preferSlideShowWindow || IsInSlideShow;
+                                if (shouldUseSlideShowWindow && slideShowWindows != null)
                                 {
-                                    dynamic ssw = slideShowWindows;
-                                    if (ssw.Count > 0)
+                                    if (knownSlideShowWindow != null)
                                     {
-                                        slideShowWindow = ssw[1];
-                                        if (slideShowWindow != null)
+                                        slideShowWindow = knownSlideShowWindow;
+                                    }
+                                    else
+                                    {
+                                        dynamic ssw = slideShowWindows;
+                                        if (ssw.Count > 0)
                                         {
-                                            dynamic sswObj = slideShowWindow;
-                                            view = sswObj.View;
-                                            if (view != null)
-                                            {
-                                                dynamic viewObj = view;
+                                            slideShowWindow = ssw[1];
+                                        }
+                                    }
+
+                                    if (slideShowWindow != null)
+                                    {
+                                        dynamic sswObj = slideShowWindow;
+                                        view = sswObj.View;
+                                        if (view != null)
+                                        {
+                                            dynamic viewObj = view;
                                             CurrentSlide = viewObj.Slide as Slide;
-                                            }
                                         }
                                     }
                                 }
@@ -633,7 +643,7 @@ namespace Ink_Canvas.Helpers
                             catch (COMException comEx)
                             {
                                 var hr = (uint)comEx.HResult;
-                                if (hr != 0x8001010E && hr != 0x80004005)
+                                if (hr != 0x8001010E && hr != 0x80004005 && !IsNoActivePresentationOrWindowHResult(hr))
                                 {
                                     LogHelper.WriteLogToFile($"获取当前幻灯片失败: {comEx.Message}", LogHelper.LogType.Warning);
                                 }
@@ -655,7 +665,7 @@ namespace Ink_Canvas.Helpers
                     catch (COMException comEx)
                     {
                         var hr = (uint)comEx.HResult;
-                        if (hr == 0x8001010E || hr == 0x80004005)
+                        if (hr == 0x8001010E || hr == 0x80004005 || IsNoActivePresentationOrWindowHResult(hr))
                         {
                             CurrentPresentation = null;
                             CurrentSlides = null;
@@ -698,6 +708,61 @@ namespace Ink_Canvas.Helpers
                 }
             }
         }
+
+        private object TryGetActivePresentation(SlideShowWindow knownSlideShowWindow)
+        {
+            try
+            {
+                return PPTApplication.ActivePresentation;
+            }
+            catch (COMException comEx)
+            {
+                var hr = (uint)comEx.HResult;
+                if (!IsNoActivePresentationOrWindowHResult(hr))
+                {
+                    throw;
+                }
+            }
+
+            try
+            {
+                if (knownSlideShowWindow != null)
+                {
+                    return knownSlideShowWindow.Presentation;
+                }
+
+                var slideShowWindows = PPTApplication.SlideShowWindows;
+                if (slideShowWindows == null)
+                {
+                    return null;
+                }
+
+                dynamic ssw = slideShowWindows;
+                if (ssw.Count == 0)
+                {
+                    return null;
+                }
+
+                var slideShowWindow = ssw[1];
+                if (slideShowWindow == null)
+                {
+                    return null;
+                }
+
+                dynamic sswObj = slideShowWindow;
+                return sswObj.Presentation;
+            }
+            catch (COMException comEx)
+            {
+                var hr = (uint)comEx.HResult;
+                if (!IsNoActivePresentationOrWindowHResult(hr))
+                {
+                    throw;
+                }
+            }
+
+            return null;
+        }
         #endregion
 
         #region Event Handlers
@@ -734,7 +799,7 @@ namespace Ink_Canvas.Helpers
             _cachedIsInSlideShow = true;
             try
             {
-                UpdateCurrentPresentationInfo();
+                UpdateCurrentPresentationInfo(preferSlideShowWindow: true, knownSlideShowWindow: wn);
                 SlideShowBegin?.Invoke(wn);
             }
             catch (Exception ex)
@@ -747,7 +812,7 @@ namespace Ink_Canvas.Helpers
         {
             try
             {
-                UpdateCurrentPresentationInfo();
+                UpdateCurrentPresentationInfo(preferSlideShowWindow: true, knownSlideShowWindow: wn);
                 SlideShowNextSlide?.Invoke(wn);
             }
             catch (Exception ex)


### PR DESCRIPTION
### Motivation
- Reduce transient errors and UI/state desync when PowerPoint enters slideshow mode, which can trigger COM HRESULT `0x80048240` (no active presentation/document window) and cause controls to disappear or the app to hang.
- Avoid accessing `ActiveWindow`/`ActivePresentation` during slideshow transitions where those COM properties may be temporarily unavailable, preventing cascade failures and slow/blocked behavior.

### Description
- Add detection helper `IsNoActivePresentationOrWindowHResult` to treat `0x80048240` as a transient condition rather than a hard error.
- Make `UpdateCurrentPresentationInfo` slideshow-aware by adding parameters `preferSlideShowWindow` and `knownSlideShowWindow` so slideshow events can provide a stable `SlideShowWindow` context.
- Introduce `TryGetActivePresentation` that first attempts `ActivePresentation` and falls back to reading the `Presentation` from a `SlideShowWindow` (or the first `SlideShowWindows` entry) when `ActivePresentation` throws `0x80048240`.
- Update `OnSlideShowBegin` and `OnSlideShowNextSlide` to pass the event `SlideShowWindow` into `UpdateCurrentPresentationInfo`, and relax COM-exception logging to ignore the transient `0x80048240` case.

### Testing
- Ran `dotnet --version` in the current environment to attempt a build/runtime check, which failed with `dotnet: command not found` so no automated .NET tests could be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a8fe16f568832c9aff15061d2f1c42)