### PR TITLE
Reset heartbeat at startup completion to avoid false watchdog restart

### DIFF
--- a/Ink Canvas/App.xaml.cs
+++ b/Ink Canvas/App.xaml.cs
@@ -1079,6 +1079,8 @@ namespace Ink_Canvas
             {
                 isStartupComplete = true;
                 startupCompleteHeartbeat = DateTime.Now;
+                // 启动完成时重置心跳时间，避免启动阶段主线程长时间忙碌导致误判为“无响应”
+                lastHeartbeat = startupCompleteHeartbeat;
                 if (_isSplashScreenShown && splashScreenStartTime != DateTime.MinValue)
                 {
                     LogHelper.WriteLogToFile($"启动完成心跳已记录，启动画面显示时长: {(startupCompleteHeartbeat - splashScreenStartTime).TotalSeconds:F2}秒");


### PR DESCRIPTION
### Motivation
- Logs showed the watchdog could detect the main thread as unresponsive immediately after startup because the `lastHeartbeat` timestamp could be stale at the moment `isStartupComplete` becomes true, causing a false positive restart.

### Description
- In `Ink Canvas/App.xaml.cs` set `lastHeartbeat = startupCompleteHeartbeat` inside the `mainWindow.Loaded` handler right after `isStartupComplete = true` to align the watchdog baseline with the actual startup-complete moment.

### Testing
- Applied the patch and verified the modification appears via repository checks using `git diff` and `git status`, confirming the new `lastHeartbeat` assignment is present (no unit tests were run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ae8b8dcc70832c86b815d28490c803)