### PR TITLE
Fix PowerPoint disconnect crash on stale COM objects

### DIFF
--- a/Ink Canvas/Helpers/ROTPPTManager.cs
+++ b/Ink Canvas/Helpers/ROTPPTManager.cs
@@ -1344,10 +1344,22 @@ namespace Ink_Canvas.Helpers
             catch { }
         }
 
+        private static bool IsObjectNull(object comObject)
+        {
+            return ReferenceEquals(comObject, null);
+        }
+
         private void DisconnectFromPPT()
         {
-            if (PPTApplication == null && _pptActivePresentation == null && _pptSlideShowWindow == null &&
-                CurrentPresentation == null && CurrentSlides == null && CurrentSlide == null)
+            object pptApplication = PPTApplication;
+            object activePresentation = _pptActivePresentation;
+            object slideShowWindow = _pptSlideShowWindow;
+            object currentPresentation = CurrentPresentation;
+            object currentSlides = CurrentSlides;
+            object currentSlide = CurrentSlide;
+
+            if (IsObjectNull(pptApplication) && IsObjectNull(activePresentation) && IsObjectNull(slideShowWindow) &&
+                IsObjectNull(currentPresentation) && IsObjectNull(currentSlides) && IsObjectNull(currentSlide))
             {
                 return;
             }


### PR DESCRIPTION
### Motivation
- Prevent crashes occurring during PPT cleanup when a stale COM proxy (RPC server unavailable) triggers the dynamic binder while evaluating `null` checks. 
- Make the early-return guard in `DisconnectFromPPT` safe against RPC/COM failures so teardown does not itself throw a `COMException` or crash the process.

### Description
- Added a helper `IsObjectNull(object comObject)` that uses `ReferenceEquals` to test for null without invoking the dynamic binder. 
- Snapshot `PPTApplication`, `_pptActivePresentation`, `_pptSlideShowWindow`, `CurrentPresentation`, `CurrentSlides`, and `CurrentSlide` into local `object` variables and use `IsObjectNull` for the early-return guard in `DisconnectFromPPT` to avoid touching dynamic COM proxies. 
- Changes are made in `Ink Canvas/Helpers/ROTPPTManager.cs` around the `DisconnectFromPPT` implementation.

### Testing
- Attempted to build the solution with `dotnet build 'Ink Canvas.sln'`, but the run failed in this environment because the `dotnet` SDK is not installed (`/bin/bash: line 1: dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c0fa99b1ac832c91b6c5796f22dfbe)