### PR TITLE
refactor: 替换任务栏图标库为 H.NotifyIcon

### DIFF
--- a/Ink Canvas/App.xaml
+++ b/Ink Canvas/App.xaml
@@ -2,7 +2,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="clr-namespace:Ink_Canvas"
-             xmlns:tb="http://www.hardcodet.net/taskbar"
+             xmlns:tb="clr-namespace:H.NotifyIcon;assembly=H.NotifyIcon.Wpf"
              xmlns:ui="http://schemas.inkore.net/lib/ui/wpf/modern"
              xmlns:ikw="http://schemas.inkore.net/lib/ui/wpf"
 >

--- a/Ink Canvas/App.xaml.cs
+++ b/Ink Canvas/App.xaml.cs
@@ -1,4 +1,4 @@
-using Hardcodet.Wpf.TaskbarNotification;
+using H.NotifyIcon;
 using Ink_Canvas.Helpers;
 using Ink_Canvas.Properties;
 using iNKORE.UI.WPF.Modern.Controls;
@@ -1061,6 +1061,7 @@ namespace Ink_Canvas
             }
 
             _taskbar = (TaskbarIcon)FindResource("TaskbarTrayIcon");
+            _taskbar.ForceCreate();
 
             StartArgs = e.Args;
 

--- a/Ink Canvas/Helpers/WindowsNotificationHelper.cs
+++ b/Ink Canvas/Helpers/WindowsNotificationHelper.cs
@@ -1,4 +1,4 @@
-using Hardcodet.Wpf.TaskbarNotification;
+using H.NotifyIcon;
 using Microsoft.Toolkit.Uwp.Notifications;
 using System;
 using System.Windows;
@@ -40,10 +40,9 @@ namespace Ink_Canvas.Helpers
 
                     taskbar.Visibility = Visibility.Visible;
 
-                    taskbar.ShowBalloonTip(
+                    taskbar.ShowNotification(
                         "InkCanvasForClass CE",
-                        $"发现新版本！：{version}",
-                        BalloonIcon.Info);
+                        $"发现新版本！：{version}");
                 }
                 catch
                 {

--- a/Ink Canvas/InkCanvasForClass.csproj
+++ b/Ink Canvas/InkCanvasForClass.csproj
@@ -135,7 +135,7 @@
     <PackageReference Include="Costura.Fody" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Hardcodet.NotifyIcon.Wpf" Version="2.0.1" />
+    <PackageReference Include="H.NotifyIcon.Wpf" Version="2.0.131" />
     <PackageReference Include="iNKORE.UI.WPF.Modern" Version="0.10.2.1" />
     <PackageReference Include="iNKORE.UI.WPF" Version="1.2.8" />
     <PackageReference Include="MdXaml" Version="1.27.0" />

--- a/Ink Canvas/MainWindow_cs/MW_Settings.cs
+++ b/Ink Canvas/MainWindow_cs/MW_Settings.cs
@@ -1,4 +1,4 @@
-using Hardcodet.Wpf.TaskbarNotification;
+using H.NotifyIcon;
 using Ink_Canvas.Helpers;
 using Newtonsoft.Json;
 using OSVersionExtension;

--- a/Ink Canvas/MainWindow_cs/MW_SettingsToLoad.cs
+++ b/Ink Canvas/MainWindow_cs/MW_SettingsToLoad.cs
@@ -1,4 +1,4 @@
-using Hardcodet.Wpf.TaskbarNotification;
+using H.NotifyIcon;
 using Ink_Canvas.Helpers;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;

--- a/Ink Canvas/MainWindow_cs/MW_TrayIcon.cs
+++ b/Ink Canvas/MainWindow_cs/MW_TrayIcon.cs
@@ -1,4 +1,4 @@
-using Hardcodet.Wpf.TaskbarNotification;
+using H.NotifyIcon;
 using Ink_Canvas.Helpers;
 using iNKORE.UI.WPF.Controls;
 using System;

--- a/Ink Canvas/Windows/SettingsViews/SettingsViews/ThemePanel.xaml.cs
+++ b/Ink Canvas/Windows/SettingsViews/SettingsViews/ThemePanel.xaml.cs
@@ -1,4 +1,4 @@
-using Hardcodet.Wpf.TaskbarNotification;
+using H.NotifyIcon;
 using iNKORE.UI.WPF.Helpers;
 using System;
 using System.Collections.Generic;

--- a/Ink Canvas/packages.lock.json
+++ b/Ink Canvas/packages.lock.json
@@ -48,11 +48,15 @@
           "Fody": "6.8.2"
         }
       },
-      "Hardcodet.NotifyIcon.Wpf": {
+      "H.NotifyIcon.Wpf": {
         "type": "Direct",
-        "requested": "[2.0.1, )",
-        "resolved": "2.0.1",
-        "contentHash": "dtxmeZXzV2GzSm91aZ3hqzgoeVoARSkDPVCYfhVUNyyKBWYxMgNC0EcLiSYxD4Uc4alq/2qb3SmV8DgAENLRLQ=="
+        "requested": "[2.0.131, )",
+        "resolved": "2.0.131",
+        "contentHash": "f71kXNl6PjCqipJ7DQytg1QUBMQ+7j8rF1UyL8UPegymG1G57EYsskdIcf/VmF6JDuts6Dk6F8Hd4ziiz4/3Dw==",
+        "dependencies": {
+          "H.NotifyIcon": "2.0.131",
+          "System.ValueTuple": "4.5.0"
+        }
       },
       "iNKORE.UI.WPF": {
         "type": "Direct",
@@ -184,6 +188,19 @@
         "type": "Transitive",
         "resolved": "6.8.2",
         "contentHash": "sjGHrtGS1+kcrv99WXCvujOFBTQp4zCH3ZC9wo2LAtVaJkuLpHghQx3y4k1Q8ZKuDAbEw+HE6ZjPUJQK3ejepQ=="
+      },
+      "H.GeneratedIcons.System.Drawing": {
+        "type": "Transitive",
+        "resolved": "2.0.131",
+        "contentHash": "QoNGQrhxzG+dQufa4xRjSqihMy5aVVVZqQUt0fLJbwhs7rcM4hpN1qVkZpZEkHsRgrHfFBC/Ursjh8STY/sg7A=="
+      },
+      "H.NotifyIcon": {
+        "type": "Transitive",
+        "resolved": "2.0.131",
+        "contentHash": "mdznQAfcJFehblFoDUvtmdm1Y9+u1eMN1ffORbdYv5EwreMxkCwvdj8qQn3qnUo9EIJ6h5Xdgqey9Nj4us8w7w==",
+        "dependencies": {
+          "H.GeneratedIcons.System.Drawing": "2.0.131"
+        }
       },
       "MdXaml.Plugins": {
         "type": "Transitive",


### PR DESCRIPTION
更新所有相关文件和引用，从 Hardcodet.Wpf.TaskbarNotification 迁移到 H.NotifyIcon 调整通知显示方式并添加 ForceCreate 调用确保图标正确显示