### PR TITLE
feat: add '包含墨迹' toggle and ink-overlay support for area screenshots

### DIFF
--- a/Ink Canvas/MainWindow_cs/MW_ImageInsert.cs
+++ b/Ink Canvas/MainWindow_cs/MW_ImageInsert.cs
@@ -218,14 +218,17 @@ namespace Ink_Canvas
         }
 
         /// <summary>
-        /// 显示截图区域选择器
+        /// 显示截图区域选择器并返回用户的截图结果（区域截图或摄像头截图）。
         /// </summary>
-        /// <returns>截图结果，包含区域、路径和摄像头截图信息</returns>
+        /// <param name="inkOverlayPreview">当用户选择包含墨迹的区域截图时，用于作为墨迹叠加的预览 <see cref="BitmapSource"/>；可为 <c>null</c>。</param>
+        /// <returns>若用户确认截图则返回 <see cref="ScreenshotResult"/>，否则返回 <c>null</c>。返回的结果可能为摄像头截图或区域截图，摄像头截图会包含 <see cref="ScreenshotResult.CameraBitmapSource"/> 或 <see cref="ScreenshotResult.CameraImage"/>，区域截图会包含有效的区域与路径。</returns>
         /// <remarks>
         /// 该方法会：
-        /// 1. 显示截图选择器窗口
-        /// 2. 获取用户选择的区域或摄像头截图
-        /// 3. 返回截图结果
+        /// 1. 在 UI 线程（通过 <see cref="Application.Current.Dispatcher"/>）上显示截图选择器窗口 <see cref="ScreenshotSelectorWindow"/>；
+        /// 2. 获取用户选择的区域截图或摄像头截图；
+        /// 3. 根据用户选择构建并返回 <see cref="ScreenshotResult"/>；
+        /// 4. 若用户取消对话框或未确认截图，返回 <c>null</c>；
+        /// 5. 方法内部捕获异常并记录日志（不会向调用方抛出异常），如需外部处理请调整实现以重新抛出或传回错误信息。
         /// </remarks>
         private async Task<ScreenshotResult?> ShowScreenshotSelector(BitmapSource inkOverlayPreview = null)
         {

--- a/Ink Canvas/MainWindow_cs/MW_ImageInsert.cs
+++ b/Ink Canvas/MainWindow_cs/MW_ImageInsert.cs
@@ -359,21 +359,21 @@ namespace Ink_Canvas
                 // PointToScreen 返回WPF坐标（DIP），统一转换为设备像素后再与 VirtualScreen 对齐
                 var inkTopLeftDip = inkCanvas.PointToScreen(new Point(0, 0));
                 var inkTopLeftPx = transformToDevice.Transform(inkTopLeftDip);
-
-                var inkRectPx = new Rect(
-                    Math.Round(inkTopLeftPx.X - virtualScreen.Left),
-                    Math.Round(inkTopLeftPx.Y - virtualScreen.Top),
-                    Math.Round(inkCanvas.ActualWidth * transformToDevice.M11),
-                    Math.Round(inkCanvas.ActualHeight * transformToDevice.M22));
+                var offsetX = inkTopLeftPx.X - virtualScreen.Left;
+                var offsetY = inkTopLeftPx.Y - virtualScreen.Top;
+                var strokes = inkCanvas.Strokes.Clone();
 
                 var drawingVisual = new DrawingVisual();
                 using (var dc = drawingVisual.RenderOpen())
                 {
-                    var visualBrush = new VisualBrush(inkCanvas)
-                    {
-                        Stretch = Stretch.Fill
-                    };
-                    dc.DrawRectangle(visualBrush, null, inkRectPx);
+                    // 直接绘制墨迹，避免 VisualBrush 在不同 DPI/布局下产生轻微偏移
+                    var matrix = new Matrix(
+                        transformToDevice.M11, 0,
+                        0, transformToDevice.M22,
+                        offsetX, offsetY);
+                    dc.PushTransform(new MatrixTransform(matrix));
+                    strokes.Draw(dc);
+                    dc.Pop();
                 }
 
                 var rtb = new RenderTargetBitmap(

--- a/Ink Canvas/MainWindow_cs/MW_ImageInsert.cs
+++ b/Ink Canvas/MainWindow_cs/MW_ImageInsert.cs
@@ -374,11 +374,12 @@ namespace Ink_Canvas
                     dc.DrawRectangle(visualBrush, null, inkRectDip);
                 }
 
+                var dpi = 96.0 * dpiScale;
                 var rtb = new RenderTargetBitmap(
                     Math.Max(1, virtualScreen.Width),
                     Math.Max(1, virtualScreen.Height),
-                    96,
-                    96,
+                    dpi,
+                    dpi,
                     PixelFormats.Pbgra32);
                 rtb.Render(drawingVisual);
                 rtb.Freeze();

--- a/Ink Canvas/MainWindow_cs/MW_ImageInsert.cs
+++ b/Ink Canvas/MainWindow_cs/MW_ImageInsert.cs
@@ -30,15 +30,19 @@ namespace Ink_Canvas
         public Bitmap CameraImage;
         public BitmapSource CameraBitmapSource;
         public bool AddToWhiteboard;
+        public bool IncludeInk;
+        public BitmapSource InkOverlayBitmapSource;
 
         public ScreenshotResult(Rectangle area, List<Point> path = null, Bitmap cameraImage = null,
-            BitmapSource cameraBitmapSource = null, bool addToWhiteboard = false)
+            BitmapSource cameraBitmapSource = null, bool addToWhiteboard = false, bool includeInk = false, BitmapSource inkOverlayBitmapSource = null)
         {
             Area = area;
             Path = path;
             CameraImage = cameraImage;
             CameraBitmapSource = cameraBitmapSource;
             AddToWhiteboard = addToWhiteboard;
+            IncludeInk = includeInk;
+            InkOverlayBitmapSource = inkOverlayBitmapSource;
         }
     }
 
@@ -60,6 +64,8 @@ namespace Ink_Canvas
         {
             try
             {
+                var inkOverlayPreview = CreateInkOverlayPreviewBitmapSource();
+
                 // 隐藏主窗口以避免截图包含窗口本身
                 var originalVisibility = Visibility;
                 Visibility = Visibility.Hidden;
@@ -68,7 +74,7 @@ namespace Ink_Canvas
                 await Task.Delay(200);
 
                 // 启动区域选择截图
-                var screenshotResult = await ShowScreenshotSelector();
+                var screenshotResult = await ShowScreenshotSelector(inkOverlayPreview);
 
                 // 恢复窗口显示
                 Visibility = originalVisibility;
@@ -104,11 +110,33 @@ namespace Ink_Canvas
 
                                 try
                                 {
+                                    if (screenshotResult.Value.IncludeInk && screenshotResult.Value.InkOverlayBitmapSource != null)
+                                    {
+                                        var withInkBitmap = OverlayInkOnCapturedBitmap(finalBitmap, screenshotResult.Value.Area, screenshotResult.Value.InkOverlayBitmapSource);
+                                        if (withInkBitmap != null && withInkBitmap != finalBitmap)
+                                        {
+                                            if (needDisposeFinalBitmap && finalBitmap != originalBitmap)
+                                            {
+                                                finalBitmap.Dispose();
+                                            }
+                                            finalBitmap = withInkBitmap;
+                                            needDisposeFinalBitmap = true;
+                                        }
+                                    }
+
                                     // 如果有路径信息，应用形状遮罩
                                     if (screenshotResult.Value.Path != null && screenshotResult.Value.Path.Count > 0)
                                     {
-                                        finalBitmap = ApplyShapeMask(originalBitmap, screenshotResult.Value.Path, screenshotResult.Value.Area);
-                                        needDisposeFinalBitmap = true; // 标记需要释放新创建的位图
+                                        var maskedBitmap = ApplyShapeMask(finalBitmap, screenshotResult.Value.Path, screenshotResult.Value.Area);
+                                        if (maskedBitmap != null && maskedBitmap != finalBitmap)
+                                        {
+                                            if (needDisposeFinalBitmap && finalBitmap != originalBitmap)
+                                            {
+                                                finalBitmap.Dispose();
+                                            }
+                                            finalBitmap = maskedBitmap;
+                                            needDisposeFinalBitmap = true; // 标记需要释放新创建的位图
+                                        }
                                     }
 
                                     // 将截图转换为WPF Image并插入到画布
@@ -199,7 +227,7 @@ namespace Ink_Canvas
         /// 2. 获取用户选择的区域或摄像头截图
         /// 3. 返回截图结果
         /// </remarks>
-        private async Task<ScreenshotResult?> ShowScreenshotSelector()
+        private async Task<ScreenshotResult?> ShowScreenshotSelector(BitmapSource inkOverlayPreview = null)
         {
             ScreenshotResult? result = null;
 
@@ -207,7 +235,7 @@ namespace Ink_Canvas
             {
                 await Application.Current.Dispatcher.InvokeAsync(() =>
                 {
-                    var selectorWindow = new ScreenshotSelectorWindow();
+                    var selectorWindow = new ScreenshotSelectorWindow(inkOverlayPreview);
                     if (selectorWindow.ShowDialog() == true)
                     {
                         // 检查是否是摄像头截图
@@ -218,7 +246,9 @@ namespace Ink_Canvas
                                 null, // 摄像头截图不需要路径
                                 null, // 不再使用Bitmap
                                 selectorWindow.CameraBitmapSource, // 摄像头BitmapSource
-                                selectorWindow.ShouldAddToWhiteboard
+                                selectorWindow.ShouldAddToWhiteboard,
+                                false,
+                                null
                             );
                         }
                         else if (selectorWindow.CameraImage != null)
@@ -228,7 +258,9 @@ namespace Ink_Canvas
                                 null, // 摄像头截图不需要路径
                                 selectorWindow.CameraImage, // 摄像头图像
                                 null,
-                                selectorWindow.ShouldAddToWhiteboard
+                                selectorWindow.ShouldAddToWhiteboard,
+                                false,
+                                null
                             );
                         }
                         else
@@ -238,7 +270,9 @@ namespace Ink_Canvas
                                 selectorWindow.SelectedPath,
                                 null,
                                 null,
-                                selectorWindow.ShouldAddToWhiteboard
+                                selectorWindow.ShouldAddToWhiteboard,
+                                selectorWindow.IncludeInkInScreenshot,
+                                selectorWindow.IncludeInkInScreenshot ? inkOverlayPreview : null
                             );
                         }
                     }
@@ -301,6 +335,127 @@ namespace Ink_Canvas
             {
                 LogHelper.WriteLogToFile($"截取屏幕区域失败: {ex.Message}", LogHelper.LogType.Error);
                 return null;
+            }
+        }
+
+        private BitmapSource CreateInkOverlayPreviewBitmapSource()
+        {
+            try
+            {
+                if (inkCanvas == null || inkCanvas.Strokes == null || inkCanvas.Strokes.Count == 0)
+                {
+                    return null;
+                }
+
+                if (inkCanvas.ActualWidth <= 0 || inkCanvas.ActualHeight <= 0)
+                {
+                    return null;
+                }
+
+                var virtualScreen = SystemInformation.VirtualScreen;
+                var dpiScale = GetDpiScale();
+                var virtualLeftDip = virtualScreen.Left / dpiScale;
+                var virtualTopDip = virtualScreen.Top / dpiScale;
+
+                var inkTopLeftInWindow = inkCanvas.TranslatePoint(new Point(0, 0), this);
+                var inkRectDip = new Rect(
+                    (Left + inkTopLeftInWindow.X) - virtualLeftDip,
+                    (Top + inkTopLeftInWindow.Y) - virtualTopDip,
+                    inkCanvas.ActualWidth,
+                    inkCanvas.ActualHeight);
+
+                var drawingVisual = new DrawingVisual();
+                using (var dc = drawingVisual.RenderOpen())
+                {
+                    var visualBrush = new VisualBrush(inkCanvas)
+                    {
+                        Stretch = Stretch.Fill
+                    };
+                    dc.DrawRectangle(visualBrush, null, inkRectDip);
+                }
+
+                var rtb = new RenderTargetBitmap(
+                    Math.Max(1, virtualScreen.Width),
+                    Math.Max(1, virtualScreen.Height),
+                    96,
+                    96,
+                    PixelFormats.Pbgra32);
+                rtb.Render(drawingVisual);
+                rtb.Freeze();
+                return rtb;
+            }
+            catch (Exception ex)
+            {
+                LogHelper.WriteLogToFile($"创建截图墨迹预览失败: {ex.Message}", LogHelper.LogType.Warning);
+                return null;
+            }
+        }
+
+        private Bitmap OverlayInkOnCapturedBitmap(Bitmap capturedBitmap, Rectangle captureArea, BitmapSource inkOverlayBitmapSource)
+        {
+            if (capturedBitmap == null || inkOverlayBitmapSource == null)
+            {
+                return capturedBitmap;
+            }
+
+            try
+            {
+                var virtualScreen = SystemInformation.VirtualScreen;
+                var sourceRect = new Rectangle(
+                    captureArea.X - virtualScreen.X,
+                    captureArea.Y - virtualScreen.Y,
+                    captureArea.Width,
+                    captureArea.Height);
+
+                sourceRect.Intersect(new Rectangle(0, 0, inkOverlayBitmapSource.PixelWidth, inkOverlayBitmapSource.PixelHeight));
+                if (sourceRect.Width <= 0 || sourceRect.Height <= 0)
+                {
+                    return capturedBitmap;
+                }
+
+                using (var inkOverlayBitmap = ConvertBitmapSourceToBitmap(inkOverlayBitmapSource))
+                {
+                    if (inkOverlayBitmap == null)
+                    {
+                        return capturedBitmap;
+                    }
+
+                    var resultBitmap = new Bitmap(capturedBitmap.Width, capturedBitmap.Height, PixelFormat.Format32bppArgb);
+                    using (var g = Graphics.FromImage(resultBitmap))
+                    {
+                        g.DrawImage(capturedBitmap, 0, 0, capturedBitmap.Width, capturedBitmap.Height);
+
+                        var targetRect = new Rectangle(0, 0, Math.Min(sourceRect.Width, capturedBitmap.Width), Math.Min(sourceRect.Height, capturedBitmap.Height));
+                        g.DrawImage(inkOverlayBitmap, targetRect, sourceRect, GraphicsUnit.Pixel);
+                    }
+
+                    return resultBitmap;
+                }
+            }
+            catch (Exception ex)
+            {
+                LogHelper.WriteLogToFile($"叠加截图墨迹失败: {ex.Message}", LogHelper.LogType.Warning);
+                return capturedBitmap;
+            }
+        }
+
+        private Bitmap ConvertBitmapSourceToBitmap(BitmapSource bitmapSource)
+        {
+            if (bitmapSource == null)
+            {
+                return null;
+            }
+
+            using (var memoryStream = new MemoryStream())
+            {
+                var encoder = new PngBitmapEncoder();
+                encoder.Frames.Add(BitmapFrame.Create(bitmapSource));
+                encoder.Save(memoryStream);
+                memoryStream.Position = 0;
+                using (var tempBitmap = new Bitmap(memoryStream))
+                {
+                    return new Bitmap(tempBitmap);
+                }
             }
         }
 

--- a/Ink Canvas/MainWindow_cs/MW_ImageInsert.cs
+++ b/Ink Canvas/MainWindow_cs/MW_ImageInsert.cs
@@ -354,7 +354,7 @@ namespace Ink_Canvas
 
                 var virtualScreen = SystemInformation.VirtualScreen;
                 var source = PresentationSource.FromVisual(inkCanvas);
-                var transformToDevice = source?.CompositionTarget?.TransformToDevice ?? Matrix.Identity;
+                var transformToDevice = source?.CompositionTarget?.TransformToDevice ?? System.Windows.Media.Matrix.Identity;
 
                 // PointToScreen 返回WPF坐标（DIP），统一转换为设备像素后再与 VirtualScreen 对齐
                 var inkTopLeftDip = inkCanvas.PointToScreen(new Point(0, 0));
@@ -367,7 +367,7 @@ namespace Ink_Canvas
                 using (var dc = drawingVisual.RenderOpen())
                 {
                     // 直接绘制墨迹，避免 VisualBrush 在不同 DPI/布局下产生轻微偏移
-                    var matrix = new Matrix(
+                    var matrix = new System.Windows.Media.Matrix(
                         transformToDevice.M11, 0,
                         0, transformToDevice.M22,
                         offsetX, offsetY);

--- a/Ink Canvas/MainWindow_cs/MW_ImageInsert.cs
+++ b/Ink Canvas/MainWindow_cs/MW_ImageInsert.cs
@@ -342,7 +342,12 @@ namespace Ink_Canvas
         {
             try
             {
-                if (inkCanvas == null || inkCanvas.Strokes == null || inkCanvas.Strokes.Count == 0)
+                if (inkCanvas == null)
+                {
+                    return null;
+                }
+
+                if ((inkCanvas.Strokes?.Count ?? 0) == 0 && inkCanvas.Children.Count == 0)
                 {
                     return null;
                 }
@@ -361,19 +366,18 @@ namespace Ink_Canvas
                 var inkTopLeftPx = transformToDevice.Transform(inkTopLeftDip);
                 var offsetX = inkTopLeftPx.X - virtualScreen.Left;
                 var offsetY = inkTopLeftPx.Y - virtualScreen.Top;
-                var strokes = inkCanvas.Strokes.Clone();
+                var widthPx = inkCanvas.ActualWidth * transformToDevice.M11;
+                var heightPx = inkCanvas.ActualHeight * transformToDevice.M22;
 
                 var drawingVisual = new DrawingVisual();
                 using (var dc = drawingVisual.RenderOpen())
                 {
-                    // 直接绘制墨迹，避免 VisualBrush 在不同 DPI/布局下产生轻微偏移
-                    var matrix = new System.Windows.Media.Matrix(
-                        transformToDevice.M11, 0,
-                        0, transformToDevice.M22,
-                        offsetX, offsetY);
-                    dc.PushTransform(new MatrixTransform(matrix));
-                    strokes.Draw(dc);
-                    dc.Pop();
+                    // 使用完整 InkCanvas 视觉树，确保包含图片等子元素
+                    var visualBrush = new VisualBrush(inkCanvas)
+                    {
+                        Stretch = Stretch.Fill
+                    };
+                    dc.DrawRectangle(visualBrush, null, new Rect(offsetX, offsetY, widthPx, heightPx));
                 }
 
                 var rtb = new RenderTargetBitmap(
@@ -422,16 +426,25 @@ namespace Ink_Canvas
                         return capturedBitmap;
                     }
 
-                    var resultBitmap = new Bitmap(capturedBitmap.Width, capturedBitmap.Height, PixelFormat.Format32bppArgb);
-                    using (var g = Graphics.FromImage(resultBitmap))
+                    Bitmap resultBitmap = null;
+                    try
                     {
-                        g.DrawImage(capturedBitmap, 0, 0, capturedBitmap.Width, capturedBitmap.Height);
+                        resultBitmap = new Bitmap(capturedBitmap.Width, capturedBitmap.Height, PixelFormat.Format32bppArgb);
+                        using (var g = Graphics.FromImage(resultBitmap))
+                        {
+                            g.DrawImage(capturedBitmap, 0, 0, capturedBitmap.Width, capturedBitmap.Height);
 
-                        var targetRect = new Rectangle(0, 0, Math.Min(sourceRect.Width, capturedBitmap.Width), Math.Min(sourceRect.Height, capturedBitmap.Height));
-                        g.DrawImage(inkOverlayBitmap, targetRect, sourceRect, GraphicsUnit.Pixel);
+                            var targetRect = new Rectangle(0, 0, Math.Min(sourceRect.Width, capturedBitmap.Width), Math.Min(sourceRect.Height, capturedBitmap.Height));
+                            g.DrawImage(inkOverlayBitmap, targetRect, sourceRect, GraphicsUnit.Pixel);
+                        }
+
+                        return resultBitmap;
                     }
-
-                    return resultBitmap;
+                    catch
+                    {
+                        resultBitmap?.Dispose();
+                        throw;
+                    }
                 }
             }
             catch (Exception ex)

--- a/Ink Canvas/MainWindow_cs/MW_ImageInsert.cs
+++ b/Ink Canvas/MainWindow_cs/MW_ImageInsert.cs
@@ -353,16 +353,18 @@ namespace Ink_Canvas
                 }
 
                 var virtualScreen = SystemInformation.VirtualScreen;
-                var dpiScale = GetDpiScale();
-                var virtualLeftDip = virtualScreen.Left / dpiScale;
-                var virtualTopDip = virtualScreen.Top / dpiScale;
+                var source = PresentationSource.FromVisual(inkCanvas);
+                var transformToDevice = source?.CompositionTarget?.TransformToDevice ?? Matrix.Identity;
 
-                var inkTopLeftInWindow = inkCanvas.TranslatePoint(new Point(0, 0), this);
-                var inkRectDip = new Rect(
-                    (Left + inkTopLeftInWindow.X) - virtualLeftDip,
-                    (Top + inkTopLeftInWindow.Y) - virtualTopDip,
-                    inkCanvas.ActualWidth,
-                    inkCanvas.ActualHeight);
+                // PointToScreen 返回WPF坐标（DIP），统一转换为设备像素后再与 VirtualScreen 对齐
+                var inkTopLeftDip = inkCanvas.PointToScreen(new Point(0, 0));
+                var inkTopLeftPx = transformToDevice.Transform(inkTopLeftDip);
+
+                var inkRectPx = new Rect(
+                    Math.Round(inkTopLeftPx.X - virtualScreen.Left),
+                    Math.Round(inkTopLeftPx.Y - virtualScreen.Top),
+                    Math.Round(inkCanvas.ActualWidth * transformToDevice.M11),
+                    Math.Round(inkCanvas.ActualHeight * transformToDevice.M22));
 
                 var drawingVisual = new DrawingVisual();
                 using (var dc = drawingVisual.RenderOpen())
@@ -371,15 +373,14 @@ namespace Ink_Canvas
                     {
                         Stretch = Stretch.Fill
                     };
-                    dc.DrawRectangle(visualBrush, null, inkRectDip);
+                    dc.DrawRectangle(visualBrush, null, inkRectPx);
                 }
 
-                var dpi = 96.0 * dpiScale;
                 var rtb = new RenderTargetBitmap(
                     Math.Max(1, virtualScreen.Width),
                     Math.Max(1, virtualScreen.Height),
-                    dpi,
-                    dpi,
+                    96,
+                    96,
                     PixelFormats.Pbgra32);
                 rtb.Render(drawingVisual);
                 rtb.Freeze();

--- a/Ink Canvas/MainWindow_cs/MW_Screenshot.cs
+++ b/Ink Canvas/MainWindow_cs/MW_Screenshot.cs
@@ -162,10 +162,11 @@ namespace Ink_Canvas
             var originalVisibility = Visibility;
             try
             {
+                var inkOverlayPreview = CreateInkOverlayPreviewBitmapSource();
                 Visibility = Visibility.Hidden;
                 await Task.Delay(200);
 
-                var screenshotResult = await ShowScreenshotSelector();
+                var screenshotResult = await ShowScreenshotSelector(inkOverlayPreview);
 
                 if (!screenshotResult.HasValue)
                 {
@@ -202,10 +203,32 @@ namespace Ink_Canvas
 
                     try
                     {
+                        if (screenshotResult.Value.IncludeInk && screenshotResult.Value.InkOverlayBitmapSource != null)
+                        {
+                            var withInkBitmap = OverlayInkOnCapturedBitmap(finalBitmap, screenshotResult.Value.Area, screenshotResult.Value.InkOverlayBitmapSource);
+                            if (withInkBitmap != null && withInkBitmap != finalBitmap)
+                            {
+                                if (needDisposeFinalBitmap && finalBitmap != originalBitmap)
+                                {
+                                    finalBitmap.Dispose();
+                                }
+                                finalBitmap = withInkBitmap;
+                                needDisposeFinalBitmap = true;
+                            }
+                        }
+
                         if (screenshotResult.Value.Path != null && screenshotResult.Value.Path.Count > 0)
                         {
-                            finalBitmap = ApplyShapeMask(originalBitmap, screenshotResult.Value.Path, screenshotResult.Value.Area);
-                            needDisposeFinalBitmap = true;
+                            var maskedBitmap = ApplyShapeMask(finalBitmap, screenshotResult.Value.Path, screenshotResult.Value.Area);
+                            if (maskedBitmap != null && maskedBitmap != finalBitmap)
+                            {
+                                if (needDisposeFinalBitmap && finalBitmap != originalBitmap)
+                                {
+                                    finalBitmap.Dispose();
+                                }
+                                finalBitmap = maskedBitmap;
+                                needDisposeFinalBitmap = true;
+                            }
                         }
 
                         var directory = Path.GetDirectoryName(desktopPath);
@@ -275,10 +298,32 @@ namespace Ink_Canvas
 
                     try
                     {
+                        if (screenshotResult.IncludeInk && screenshotResult.InkOverlayBitmapSource != null)
+                        {
+                            var withInkBitmap = OverlayInkOnCapturedBitmap(finalBitmap, screenshotResult.Area, screenshotResult.InkOverlayBitmapSource);
+                            if (withInkBitmap != null && withInkBitmap != finalBitmap)
+                            {
+                                if (needDisposeFinalBitmap && finalBitmap != originalBitmap)
+                                {
+                                    finalBitmap.Dispose();
+                                }
+                                finalBitmap = withInkBitmap;
+                                needDisposeFinalBitmap = true;
+                            }
+                        }
+
                         if (screenshotResult.Path != null && screenshotResult.Path.Count > 0)
                         {
-                            finalBitmap = ApplyShapeMask(originalBitmap, screenshotResult.Path, screenshotResult.Area);
-                            needDisposeFinalBitmap = true;
+                            var maskedBitmap = ApplyShapeMask(finalBitmap, screenshotResult.Path, screenshotResult.Area);
+                            if (maskedBitmap != null && maskedBitmap != finalBitmap)
+                            {
+                                if (needDisposeFinalBitmap && finalBitmap != originalBitmap)
+                                {
+                                    finalBitmap.Dispose();
+                                }
+                                finalBitmap = maskedBitmap;
+                                needDisposeFinalBitmap = true;
+                            }
                         }
 
                         bitmapSourceForClipboard = ConvertBitmapToBitmapSource(finalBitmap);

--- a/Ink Canvas/Windows/ScreenshotSelectorWindow.xaml
+++ b/Ink Canvas/Windows/ScreenshotSelectorWindow.xaml
@@ -36,6 +36,13 @@
             </Rectangle.Clip>
         </Rectangle>
 
+        <!-- 墨迹预览层（用于“包含墨迹”预览） -->
+        <Image Name="InkPreviewImage"
+               Stretch="Fill"
+               IsHitTestVisible="False"
+               Visibility="Collapsed"
+               Panel.ZIndex="950" />
+
         <!-- 选择区域容器 -->
         <Canvas Name="SelectionCanvas" Panel.ZIndex="1000">
             <!-- 矩形选择模式 -->
@@ -141,6 +148,17 @@
                           Background="#404040" />
                 
                 <!-- 操作按钮 -->
+                <CheckBox Name="IncludeInkCheckBox"
+                          Content="包含墨迹"
+                          Margin="4,0"
+                          VerticalAlignment="Center"
+                          Foreground="White"
+                          Checked="IncludeInkCheckBox_Checked"
+                          Unchecked="IncludeInkCheckBox_Unchecked" />
+                <Rectangle Width="1"
+                           Height="20"
+                           Fill="#404040"
+                           Margin="8,0" />
                 <Button Name="ConfirmButton"
                         Content="确认截图"
                         Margin="4,0"

--- a/Ink Canvas/Windows/ScreenshotSelectorWindow.xaml
+++ b/Ink Canvas/Windows/ScreenshotSelectorWindow.xaml
@@ -155,7 +155,8 @@
                           Foreground="White"
                           Checked="IncludeInkCheckBox_Checked"
                           Unchecked="IncludeInkCheckBox_Unchecked" />
-                <Rectangle Width="1"
+                <Rectangle Name="ToolbarDividerRectangle"
+                           Width="1"
                            Height="20"
                            Fill="#404040"
                            Margin="8,0" />

--- a/Ink Canvas/Windows/ScreenshotSelectorWindow.xaml.cs
+++ b/Ink Canvas/Windows/ScreenshotSelectorWindow.xaml.cs
@@ -7,6 +7,7 @@ using System.Windows.Controls;
 using System.Windows.Forms;
 using System.Windows.Input;
 using System.Windows.Media;
+using System.Windows.Media.Imaging;
 using System.Windows.Shapes;
 using System.Windows.Threading;
 using Brushes = System.Windows.Media.Brushes;
@@ -37,6 +38,7 @@ namespace Ink_Canvas
         private Bitmap _capturedCameraImage = null;
         private DateTime _lastBlankClickTime = DateTime.MinValue;
         private WpfPoint _lastBlankClickPosition;
+        private readonly BitmapSource _inkOverlayPreview;
 
         private const int DoubleClickTimeThresholdMs = 300; // 双击判定时间阈值（常见范围 200~500ms）
         private const double DoubleClickDistanceThresholdPx = 12; // 双击判定位置阈值（像素）
@@ -55,9 +57,11 @@ namespace Ink_Canvas
         public Bitmap CameraImage { get; private set; }
         public System.Windows.Media.Imaging.BitmapSource CameraBitmapSource { get; private set; }
         public bool ShouldAddToWhiteboard { get; private set; }
+        public bool IncludeInkInScreenshot { get; private set; }
 
-        public ScreenshotSelectorWindow()
+        public ScreenshotSelectorWindow(BitmapSource inkOverlayPreview = null)
         {
+            _inkOverlayPreview = inkOverlayPreview;
             InitializeComponent();
 
             // 设置窗口覆盖所有屏幕
@@ -71,6 +75,7 @@ namespace Ink_Canvas
 
             // 初始化按钮状态 
             InitializeButtonStates();
+            InitializeInkPreview();
 
             // 初始化摄像头服务
             InitializeCameraService();
@@ -104,6 +109,44 @@ namespace Ink_Canvas
             FreehandModeButton.Background = new SolidColorBrush(Color.FromRgb(107, 114, 128)); // 灰色
             FullScreenButton.Background = new SolidColorBrush(Color.FromRgb(107, 114, 128)); // 灰色
             CameraModeButton.Background = new SolidColorBrush(Color.FromRgb(107, 114, 128)); // 灰色
+        }
+
+        private void InitializeInkPreview()
+        {
+            IncludeInkInScreenshot = false;
+            IncludeInkCheckBox.IsChecked = false;
+
+            if (_inkOverlayPreview != null)
+            {
+                InkPreviewImage.Source = _inkOverlayPreview;
+            }
+            else
+            {
+                IncludeInkCheckBox.IsEnabled = false;
+                IncludeInkCheckBox.Opacity = 0.6;
+                IncludeInkCheckBox.ToolTip = "当前无可预览墨迹";
+            }
+
+            UpdateInkPreviewVisibility();
+        }
+
+        private void IncludeInkCheckBox_Checked(object sender, RoutedEventArgs e)
+        {
+            IncludeInkInScreenshot = true;
+            UpdateInkPreviewVisibility();
+        }
+
+        private void IncludeInkCheckBox_Unchecked(object sender, RoutedEventArgs e)
+        {
+            IncludeInkInScreenshot = false;
+            UpdateInkPreviewVisibility();
+        }
+
+        private void UpdateInkPreviewVisibility()
+        {
+            InkPreviewImage.Visibility = IncludeInkInScreenshot && _inkOverlayPreview != null
+                ? Visibility.Visible
+                : Visibility.Collapsed;
         }
 
         private void InitializeCameraService()
@@ -370,6 +413,7 @@ namespace Ink_Canvas
             RectangleModeButton.Background = new SolidColorBrush(Color.FromRgb(37, 99, 235)); // 蓝色
             FreehandModeButton.Background = new SolidColorBrush(Color.FromRgb(107, 114, 128)); // 灰色
             FullScreenButton.Background = new SolidColorBrush(Color.FromRgb(107, 114, 128)); // 灰色
+            IncludeInkCheckBox.IsEnabled = _inkOverlayPreview != null;
             HintText.Text = "拖拽鼠标选择矩形区域";
             HintTextBorder.Visibility = Visibility.Visible;
         }
@@ -383,6 +427,7 @@ namespace Ink_Canvas
             FreehandModeButton.Background = new SolidColorBrush(Color.FromRgb(37, 99, 235)); // 蓝色
             RectangleModeButton.Background = new SolidColorBrush(Color.FromRgb(107, 114, 128)); // 灰色
             FullScreenButton.Background = new SolidColorBrush(Color.FromRgb(107, 114, 128)); // 灰色
+            IncludeInkCheckBox.IsEnabled = _inkOverlayPreview != null;
             HintText.Text = "按住鼠标左键自由绘制，松开后可继续调整或重新绘制，确认后再截图";
             HintTextBorder.Visibility = Visibility.Visible;
         }
@@ -402,6 +447,7 @@ namespace Ink_Canvas
 
             // 隐藏摄像头预览
             CameraPreviewBorder.Visibility = Visibility.Collapsed;
+            IncludeInkCheckBox.IsEnabled = _inkOverlayPreview != null;
 
             // 直接执行全屏截图
             PerformFullScreenCapture();
@@ -426,6 +472,8 @@ namespace Ink_Canvas
                 CameraPreviewBorder.Visibility = Visibility.Visible;
                 HintText.Text = "摄像头预览模式，点击确认截图按钮进行截图";
                 HintTextBorder.Visibility = Visibility.Visible;
+                IncludeInkCheckBox.IsEnabled = false;
+                IncludeInkCheckBox.IsChecked = false;
 
                 // 启动摄像头预览
                 if (_cameraService != null && _cameraService.HasAvailableCameras())
@@ -491,6 +539,7 @@ namespace Ink_Canvas
         private void ConfirmButton_Click(object sender, RoutedEventArgs e)
         {
             ShouldAddToWhiteboard = false;
+            IncludeInkInScreenshot = IncludeInkCheckBox.IsChecked == true;
 
             // 在自由绘制模式下，按当前自由选区执行确认
             if (_isFreehandMode)
@@ -512,6 +561,7 @@ namespace Ink_Canvas
         private void AddToWhiteboardButton_Click(object sender, RoutedEventArgs e)
         {
             ShouldAddToWhiteboard = true;
+            IncludeInkInScreenshot = IncludeInkCheckBox.IsChecked == true;
 
             // 在自由绘制模式下，按当前自由选区执行确认
             if (_isFreehandMode)
@@ -1178,6 +1228,7 @@ namespace Ink_Canvas
             SelectedPath = null;
             CameraImage = null;
             ShouldAddToWhiteboard = false;
+            IncludeInkInScreenshot = false;
             DialogResult = false;
             Close();
         }

--- a/Ink Canvas/Windows/ScreenshotSelectorWindow.xaml.cs
+++ b/Ink Canvas/Windows/ScreenshotSelectorWindow.xaml.cs
@@ -628,10 +628,12 @@ namespace Ink_Canvas
             if (hitElement != null && (
                 hitElement is Ellipse ||
                 hitElement is System.Windows.Controls.Button ||
+                hitElement is System.Windows.Controls.CheckBox ||
                 hitElement is Border ||
                 hitElement is TextBlock ||
                 hitElement is StackPanel ||
                 hitElement is Separator ||
+                hitElement.Name == "ToolbarDividerRectangle" ||
                 hitElement.Name == "SizeInfoBorder" ||
                 hitElement.Name == "HintText" ||
                 hitElement.Name == "AdjustModeHint" ||
@@ -719,10 +721,12 @@ namespace Ink_Canvas
             if (hitElement != null && (
                 hitElement is Ellipse ||
                 hitElement is System.Windows.Controls.Button ||
+                hitElement is System.Windows.Controls.CheckBox ||
                 hitElement is Border ||
                 hitElement is TextBlock ||
                 hitElement is StackPanel ||
                 hitElement is Separator ||
+                hitElement.Name == "ToolbarDividerRectangle" ||
                 hitElement.Name == "SizeInfoBorder" ||
                 hitElement.Name == "HintText" ||
                 hitElement.Name == "AdjustModeHint"))


### PR DESCRIPTION
我嘞个豆啊，浪费额度修那个截屏偏移的bug

这玩意是之前版本带的

目前“包含墨迹”雀食会有一点点偏移，但可以忽略不计了（我1080p,windows缩放100%）

如果说有人测出来墨迹的偏移很大，再来修吧