### PR TITLE
添加 VSCode 一键运行/调试配置

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+﻿{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Launch InkCanvasForClass",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "build (InkCanvasForClass)",
+      "program": "${workspaceFolder}/Ink Canvas/bin/Debug/AnyCPU/net6.0-windows10.0.19041.0/InkCanvasForClass.exe",
+      "cwd": "${workspaceFolder}/Ink Canvas",
+      "stopAtEntry": false,
+      "console": "internalConsole"
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,18 @@
+﻿{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "build (InkCanvasForClass)",
+      "type": "shell",
+      "command": "dotnet",
+      "args": [
+        "build",
+        "Ink Canvas/InkCanvasForClass.csproj",
+        "-c",
+        "Debug"
+      ],
+      "problemMatcher": "$msCompile",
+      "group": "build"
+    }
+  ]
+}


### PR DESCRIPTION
为方便在不打开 Visual Studio 的情况下运行/调试，这个 PR 添加了 VSCode 的 .vscode/launch.json 和 tasks.json。\n\n这样开发者可以在 VSCode 里一键完成 build + 运行/调试 InkCanvasForClass，减少环境切换成本。\n\n说明：默认指向 Debug|AnyCPU 的输出路径，如需 x86/x64 可在 launch.json 中改对应目录。