### PR TITLE
Fix: 增强时光机功能处理笔划更改时的稳定性

### DIFF
--- a/Ink Canvas/MainWindow_cs/MW_TimeMachine.cs
+++ b/Ink Canvas/MainWindow_cs/MW_TimeMachine.cs
@@ -134,23 +134,35 @@ namespace Ink_Canvas
             {
                 if (item.StrokeHasBeenCleared)
                 {
-                    foreach (var strokes in item.CurrentStroke)
-                        if (canvas.Strokes.Contains(strokes))
-                            canvas.Strokes.Remove(strokes);
+                    if (item.CurrentStroke != null)
+                    {
+                        foreach (var strokes in item.CurrentStroke)
+                            if (canvas.Strokes.Contains(strokes))
+                                canvas.Strokes.Remove(strokes);
+                    }
 
-                    foreach (var strokes in item.ReplacedStroke)
-                        if (!canvas.Strokes.Contains(strokes))
-                            canvas.Strokes.Add(strokes);
+                    if (item.ReplacedStroke != null)
+                    {
+                        foreach (var strokes in item.ReplacedStroke)
+                            if (!canvas.Strokes.Contains(strokes))
+                                canvas.Strokes.Add(strokes);
+                    }
                 }
                 else
                 {
-                    foreach (var strokes in item.CurrentStroke)
-                        if (!canvas.Strokes.Contains(strokes))
-                            canvas.Strokes.Add(strokes);
+                    if (item.CurrentStroke != null)
+                    {
+                        foreach (var strokes in item.CurrentStroke)
+                            if (!canvas.Strokes.Contains(strokes))
+                                canvas.Strokes.Add(strokes);
+                    }
 
-                    foreach (var strokes in item.ReplacedStroke)
-                        if (canvas.Strokes.Contains(strokes))
-                            canvas.Strokes.Remove(strokes);
+                    if (item.ReplacedStroke != null)
+                    {
+                        foreach (var strokes in item.ReplacedStroke)
+                            if (canvas.Strokes.Contains(strokes))
+                                canvas.Strokes.Remove(strokes);
+                    }
                 }
             }
             else if (item.CommitType == TimeMachineHistoryType.Manipulation)


### PR DESCRIPTION
此次合并主要增强了时光机（撤销/重做）功能在处理笔划更改时的稳定性。通过对当前笔划和被替换笔划的数据添加空引用检查，有效避免了在恢复或撤销操作时可能引发的程序崩溃。

| 文件 | 变更 |
|------|---------|
| Ink Canvas/MainWindow_cs/MW_TimeMachine.cs | - 为 `item.CurrentStroke` 的遍历和修改逻辑添加了非空条件判断。<br>- 为 `item.ReplacedStroke` 的遍历和修改逻辑添加了非空条件判断。<br>- 确保仅在笔划集合不为空的情况下，才会执行从画布中添加或移除相关笔划的操作。 |