### PR TITLE
feat: 托盘图标支持自定义左键/右键点击动作

### DIFF
--- a/Ink Canvas/App.xaml
+++ b/Ink Canvas/App.xaml
@@ -262,6 +262,9 @@
                             Visibility="Collapsed"
                             ToolTipText="InkCanvasForClass"
                             ContextMenu="{StaticResource SysTrayMenu}"
+                            MenuActivation="None"
+                            TrayLeftMouseDown="TaskbarTrayIcon_TrayLeftMouseDown"
+                            TrayRightMouseDown="TaskbarTrayIcon_TrayRightMouseDown"
                             IconSource="/Resources/icc.ico"/>
             <ResourceDictionary.MergedDictionaries>
                 <ui:ThemeResources/>

--- a/Ink Canvas/MainWindow_cs/MW_FloatingBarIcons.cs
+++ b/Ink Canvas/MainWindow_cs/MW_FloatingBarIcons.cs
@@ -34,6 +34,8 @@ namespace Ink_Canvas
         /// </summary>
         private string _currentToolMode = "cursor";
 
+        private static Windows.SettingsViews.SettingsWindow _settingsWindow = null;
+
         #region "手勢"按鈕
 
         /// <summary>
@@ -3307,6 +3309,15 @@ namespace Ink_Canvas
         /// <param name="e">路由事件参数</param>
         internal async void BtnSettings_Click(object sender, RoutedEventArgs e)
         {
+            if (_settingsWindow != null)
+            {
+                if (_settingsWindow.WindowState == System.Windows.WindowState.Minimized)
+                    _settingsWindow.WindowState = System.Windows.WindowState.Normal;
+                _settingsWindow.Activate();
+                _settingsWindow.Focus();
+                return;
+            }
+
             try
             {
                 if (Ink_Canvas.Helpers.SecurityManager.IsPasswordRequiredForEnterSettings(Settings))
@@ -3322,10 +3333,11 @@ namespace Ink_Canvas
             }
 
             HideSubPanels();
-            var settingsWindow = new Windows.SettingsViews.SettingsWindow();
-            settingsWindow.Owner = this;
-            settingsWindow.Topmost = this.Topmost;
-            settingsWindow.ShowDialog();
+            _settingsWindow = new Windows.SettingsViews.SettingsWindow();
+            _settingsWindow.Owner = this;
+            _settingsWindow.Topmost = this.Topmost;
+            _settingsWindow.Closed += (s, args) => _settingsWindow = null;
+            _settingsWindow.ShowDialog();
         }
 
         private void BtnThickness_Click(object sender, RoutedEventArgs e) { }

--- a/Ink Canvas/MainWindow_cs/MW_TrayIcon.cs
+++ b/Ink Canvas/MainWindow_cs/MW_TrayIcon.cs
@@ -24,6 +24,109 @@ namespace Ink_Canvas
 
         private bool _trayTemporaryShowRestoreHideChecked;
 
+        private void TaskbarTrayIcon_TrayLeftMouseDown(object sender, RoutedEventArgs e)
+        {
+            var action = Ink_Canvas.MainWindow.Settings.Appearance.TrayLeftClickAction;
+            ExecuteTrayClickAction(action);
+        }
+
+        private void TaskbarTrayIcon_TrayRightMouseDown(object sender, RoutedEventArgs e)
+        {
+            var action = Ink_Canvas.MainWindow.Settings.Appearance.TrayRightClickAction;
+            ExecuteTrayClickAction(action);
+        }
+
+        private void ExecuteTrayClickAction(TrayClickAction action)
+        {
+            switch (action)
+            {
+                case TrayClickAction.ShowMenu:
+                    ShowTrayContextMenu();
+                    break;
+                case TrayClickAction.HideShowMainWindow:
+                    ToggleMainWindowVisibility();
+                    break;
+                case TrayClickAction.TempShowMainWindow:
+                    TempShowMainWindowTrayIconMenuItem_Clicked(null, null);
+                    break;
+                case TrayClickAction.OpenSettings:
+                    OpenSettingsTrayIconMenuItem_Clicked(null, null);
+                    break;
+                case TrayClickAction.DisableAllHotkeys:
+                    DisableAllHotkeysMenuItem_Clicked(FindTrayMenuItem("DisableAllHotkeysMenuItem"), null);
+                    break;
+                case TrayClickAction.ForceFullScreen:
+                    ForceFullScreenTrayIconMenuItem_Clicked(null, null);
+                    break;
+                case TrayClickAction.ToggleFoldFloatingBar:
+                    FoldFloatingBarTrayIconMenuItem_Clicked(null, null);
+                    break;
+                case TrayClickAction.ResetFloatingBarPosition:
+                    ResetFloatingBarPositionTrayIconMenuItem_Clicked(null, null);
+                    break;
+                case TrayClickAction.RestartApp:
+                    RestartAppTrayIconMenuItem_Clicked(null, null);
+                    break;
+                case TrayClickAction.CloseApp:
+                    CloseAppTrayIconMenuItem_Clicked(null, null);
+                    break;
+            }
+        }
+
+        private MenuItem FindTrayMenuItem(string name)
+        {
+            try
+            {
+                var trayMenu = ((TaskbarIcon)Current.Resources["TaskbarTrayIcon"]).ContextMenu;
+                return trayMenu?.Items.OfType<MenuItem>().FirstOrDefault(mi => mi.Name == name);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private void ShowTrayContextMenu()
+        {
+            try
+            {
+                var taskbarIcon = (TaskbarIcon)Current.Resources["TaskbarTrayIcon"];
+                if (taskbarIcon?.ContextMenu != null)
+                {
+                    taskbarIcon.ContextMenu.IsOpen = true;
+                }
+            }
+            catch { }
+        }
+
+        private void ToggleMainWindowVisibility()
+        {
+            var mainWin = Current.MainWindow as MainWindow;
+            if (mainWin?.IsLoaded != true) return;
+
+            var hideItem = FindTrayMenuItem("HideICCMainWindowTrayIconMenuItem");
+            if (hideItem != null)
+            {
+                if (hideItem.IsChecked)
+                {
+                    hideItem.IsChecked = false;
+                    HideICCMainWindowTrayIconMenuItem_UnChecked(hideItem, null);
+                }
+                else
+                {
+                    hideItem.IsChecked = true;
+                    HideICCMainWindowTrayIconMenuItem_Checked(hideItem, null);
+                }
+            }
+            else
+            {
+                if (mainWin.IsVisible)
+                    mainWin.Hide();
+                else
+                    mainWin.Show();
+            }
+        }
+
         /// <summary>
         /// 系统托盘菜单打开时的事件处理方法
         /// </summary>

--- a/Ink Canvas/Resources/Settings.cs
+++ b/Ink Canvas/Resources/Settings.cs
@@ -256,6 +256,20 @@ namespace Ink_Canvas
         public bool HasShownOobe { get; set; } = false;
     }
 
+    public enum TrayClickAction
+    {
+        ShowMenu = 0,
+        HideShowMainWindow = 1,
+        TempShowMainWindow = 2,
+        OpenSettings = 3,
+        DisableAllHotkeys = 4,
+        ForceFullScreen = 5,
+        ToggleFoldFloatingBar = 6,
+        ResetFloatingBarPosition = 7,
+        RestartApp = 8,
+        CloseApp = 9
+    }
+
     public class Appearance
     {
         [JsonProperty("isEnableDisPlayNibModeToggler")]
@@ -274,6 +288,10 @@ namespace Ink_Canvas
         public double ViewboxFloatingBarOpacityValue { get; set; } = 1.0;
         [JsonProperty("enableTrayIcon")]
         public bool EnableTrayIcon { get; set; } = true;
+        [JsonProperty("trayLeftClickAction")]
+        public TrayClickAction TrayLeftClickAction { get; set; } = TrayClickAction.ShowMenu;
+        [JsonProperty("trayRightClickAction")]
+        public TrayClickAction TrayRightClickAction { get; set; } = TrayClickAction.ShowMenu;
         [JsonProperty("viewboxFloatingBarOpacityInPPTValue")]
         public double ViewboxFloatingBarOpacityInPPTValue { get; set; } = 0.5;
         [JsonProperty("viewboxBlackBoardScaleTransformValue")]

--- a/Ink Canvas/Windows/SettingsViews/Pages/AppearancePage.xaml
+++ b/Ink Canvas/Windows/SettingsViews/Pages/AppearancePage.xaml
@@ -325,6 +325,46 @@
                             SwitchName="ToggleSwitchEnableTrayIcon"
                             Toggled="ToggleSwitchEnableTrayIcon_Toggled" />
 
+                    <ui:SettingsCard Header="托盘左键点击">
+                        <ui:SettingsCard.HeaderIcon>
+                            <ui:FontIcon Icon="{x:Static ui:SegoeFluentIcons.ChevronLeft}" />
+                        </ui:SettingsCard.HeaderIcon>
+                        <ComboBox x:Name="ComboBoxTrayLeftClickAction"
+                                  SelectedIndex="0"
+                                  SelectionChanged="ComboBoxTrayLeftClickAction_SelectionChanged">
+                            <ComboBoxItem Content="打开菜单" />
+                            <ComboBoxItem Content="隐藏/显示主窗口" />
+                            <ComboBoxItem Content="临时显示主窗口" />
+                            <ComboBoxItem Content="打开设置" />
+                            <ComboBoxItem Content="禁用/启用所有快捷键" />
+                            <ComboBoxItem Content="强制全屏化" />
+                            <ComboBoxItem Content="切换浮动栏收纳模式" />
+                            <ComboBoxItem Content="重置工具栏位置" />
+                            <ComboBoxItem Content="重启软件" />
+                            <ComboBoxItem Content="退出软件" />
+                        </ComboBox>
+                    </ui:SettingsCard>
+
+                    <ui:SettingsCard Header="托盘右键点击">
+                        <ui:SettingsCard.HeaderIcon>
+                            <ui:FontIcon Icon="{x:Static ui:SegoeFluentIcons.ChevronRight}" />
+                        </ui:SettingsCard.HeaderIcon>
+                        <ComboBox x:Name="ComboBoxTrayRightClickAction"
+                                  SelectedIndex="0"
+                                  SelectionChanged="ComboBoxTrayRightClickAction_SelectionChanged">
+                            <ComboBoxItem Content="打开菜单" />
+                            <ComboBoxItem Content="隐藏/显示主窗口" />
+                            <ComboBoxItem Content="临时显示主窗口" />
+                            <ComboBoxItem Content="打开设置" />
+                            <ComboBoxItem Content="禁用/启用所有快捷键" />
+                            <ComboBoxItem Content="强制全屏化" />
+                            <ComboBoxItem Content="切换浮动栏收纳模式" />
+                            <ComboBoxItem Content="重置工具栏位置" />
+                            <ComboBoxItem Content="重启软件" />
+                            <ComboBoxItem Content="退出软件" />
+                        </ComboBox>
+                    </ui:SettingsCard>
+
                     <Rectangle Height="48" />
                 </ikw:SimpleStackPanel>
             </Grid>

--- a/Ink Canvas/Windows/SettingsViews/Pages/AppearancePage.xaml.cs
+++ b/Ink Canvas/Windows/SettingsViews/Pages/AppearancePage.xaml.cs
@@ -108,6 +108,9 @@ namespace Ink_Canvas.Windows.SettingsViews.Pages
 
             CardEnableTrayIcon.IsOn = settings.Appearance.EnableTrayIcon;
 
+            ComboBoxTrayLeftClickAction.SelectedIndex = (int)settings.Appearance.TrayLeftClickAction;
+            ComboBoxTrayRightClickAction.SelectedIndex = (int)settings.Appearance.TrayRightClickAction;
+
             if (BtnHitokotoCustomize != null)
                 BtnHitokotoCustomize.Visibility = settings.Appearance.ChickenSoupSource == 3 ? Visibility.Visible : Visibility.Collapsed;
         }
@@ -548,6 +551,20 @@ namespace Ink_Canvas.Windows.SettingsViews.Pages
                     fe.Visibility = CardEnableTrayIcon.IsOn ? Visibility.Visible : Visibility.Collapsed;
             }
             catch { }
+        }
+
+        private void ComboBoxTrayLeftClickAction_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (!_isLoaded) return;
+            SettingsManager.Settings.Appearance.TrayLeftClickAction = (TrayClickAction)ComboBoxTrayLeftClickAction.SelectedIndex;
+            SettingsManager.SaveSettingsToFile();
+        }
+
+        private void ComboBoxTrayRightClickAction_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (!_isLoaded) return;
+            SettingsManager.Settings.Appearance.TrayRightClickAction = (TrayClickAction)ComboBoxTrayRightClickAction.SelectedIndex;
+            SettingsManager.SaveSettingsToFile();
         }
 
         #endregion


### PR DESCRIPTION
## Summary
托盘图标支持自定义左键/右键点击动作，可在设置中选择点击后执行的操作。
## Changes
- 新增 `TrayClickAction` 枚举，支持 10 种动作：
  - 打开菜单
  - 隐藏/显示主窗口
  - 临时显示主窗口
  - 打开设置（已有窗口时激活，无则创建）
  - 禁用/启用所有快捷键
  - 强制全屏化
  - 切换浮动栏收纳模式
  - 重置工具栏位置
  - 重启软件
  - 退出软件
- 设置页面：
  - 新增「托盘左键点击」和「托盘右键点击」配置项
  - 默认均为「打开菜单」
- 代码优化：
  - Settings 窗口单例模式：已存在时激活已有窗口
  - `MenuActivation` 设为 `None`，全部菜单显示由手动控制