### PR TITLE
ci(workflow): 更新发布流程以支持 ReadyToRun 编译

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -227,16 +227,28 @@ jobs:
       - name: Restore Package 
         run: dotnet restore "Ink Canvas.sln" --locked-mode
       
-      - name: Build the Solution (Release)
+      - name: Publish with ReadyToRun (Release)
         env:
           DLASS_SENTRY_DSN: ${{ secrets.DLASS_SENTRY_DSN }}
         run: |
-          msbuild /p:platform="${{ matrix.architecture }}" /p:configuration="Release" /p:GitFlow="Github Action" "Ink Canvas/InkCanvasForClass.csproj" /m /p:UseMultiToolTask=true /p:EnforceProcessCountAcrossBuilds=true /verbosity:minimal -maxcpucount /p:RunAnalyzers=false
+          $platform = "${{ matrix.architecture }}"
+          if ($platform -eq "AnyCPU") {
+            $runtimeId = "win-x64"
+          } else {
+            $runtimeId = "win-x86"
+          }
+          dotnet publish "Ink Canvas/InkCanvasForClass.csproj" `
+            -c Release `
+            -r $runtimeId `
+            --self-contained true `
+            -p:Platform=$platform `
+            -p:GitFlow="Github Action" `
+            -o "Ink Canvas\bin\Release\$platform\net6.0-windows10.0.19041.0\publish"
 
       - name: Check if exe file is generated
         id: check-exe
         run: |
-          $exePath = "Ink Canvas\bin\Release\${{ matrix.architecture }}\net6.0-windows10.0.19041.0\InkCanvasForClass.exe"
+          $exePath = "Ink Canvas\bin\Release\${{ matrix.architecture }}\net6.0-windows10.0.19041.0\publish\InkCanvasForClass.exe"
           
           if (Test-Path $exePath) {
             echo "build_success=true" >> $env:GITHUB_OUTPUT
@@ -284,7 +296,7 @@ jobs:
           New-Item -ItemType Directory -Path "release" -Force
           
           # 复制发布文件（使用架构特定的路径）
-          Copy-Item "Ink Canvas\bin\Release\$architecture\net6.0-windows10.0.19041.0\*" "release/" -Recurse -Force
+          Copy-Item "Ink Canvas\bin\Release\$architecture\net6.0-windows10.0.19041.0\publish\*" "release/" -Recurse -Force
           
           # 创建压缩包
           Compress-Archive -Path "release/*" -DestinationPath $archiveName -Force

--- a/Ink Canvas/InkCanvasForClass.csproj
+++ b/Ink Canvas/InkCanvasForClass.csproj
@@ -74,6 +74,9 @@
     <PackageProjectUrl>https://inkcanvasforclass.github.io</PackageProjectUrl>
     <FileVersion>bundled</FileVersion>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
+    <PublishReadyToRun>true</PublishReadyToRun>
+    <PublishReadyToRunShowWarnings>true</PublishReadyToRunShowWarnings>
+    <PublishReadyToRunEmitSymbols>true</PublishReadyToRunEmitSymbols>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|ARM64'">
     <OutputPath>bin\$(Configuration)\$(Platform)\</OutputPath>
@@ -415,6 +418,7 @@
   </ItemGroup>
   <ItemGroup>
     <Resource Include="Resources\DeveloperAvatars\dubi906w.jpg" />
+    <Resource Include="Resources\DeveloperAvatars\CreeperAWA.png" />
   </ItemGroup>
   <ItemGroup>
     <Resource Include="Resources\new-icons\gesture.png" />

--- a/Ink Canvas/InkCanvasForClass.csproj
+++ b/Ink Canvas/InkCanvasForClass.csproj
@@ -418,7 +418,6 @@
   </ItemGroup>
   <ItemGroup>
     <Resource Include="Resources\DeveloperAvatars\dubi906w.jpg" />
-    <Resource Include="Resources\DeveloperAvatars\CreeperAWA.png" />
   </ItemGroup>
   <ItemGroup>
     <Resource Include="Resources\new-icons\gesture.png" />


### PR DESCRIPTION
修改 CI 工作流，将 MSBuild 编译替换为 dotnet publish 命令以启用 ReadyToRun 编译，同时在项目文件中添加 ReadyToRun 相关配置项

既然 [CJK 建议加](https://github.com/InkCanvasForClass/community/pull/468#issuecomment-4370115407)就加上吧，但我其实感觉优化效果不明显