### PR TITLE
适配快抽窗口明暗主题

### DIFF
--- a/Ink Canvas/MainWindow_cs/MW_AutoTheme.cs
+++ b/Ink Canvas/MainWindow_cs/MW_AutoTheme.cs
@@ -371,6 +371,10 @@ namespace Ink_Canvas
                     {
                         randWindow.RefreshTheme();
                     }
+                    else if (window is QuickDrawWindow quickDrawWindow)
+                    {
+                        quickDrawWindow.RefreshTheme();
+                    }
                     else if (window is OperatingGuideWindow operatingGuideWindow)
                     {
                         operatingGuideWindow.RefreshTheme();

--- a/Ink Canvas/Resources/Styles/Dark.xaml
+++ b/Ink Canvas/Resources/Styles/Dark.xaml
@@ -10,6 +10,12 @@
     <SolidColorBrush x:Key="QuickDrawFloatingButtonBorderBrush" Color="#40000000"/>
     <SolidColorBrush x:Key="QuickDrawFloatingButtonIconForeground" Color="White"/>
 
+    <!-- 快抽窗口主题颜色 -->
+    <SolidColorBrush x:Key="QuickDrawWindowBackground" Color="#FF1F1F1F"/>
+    <SolidColorBrush x:Key="QuickDrawWindowBorderBrush" Color="#FFE0E0E0"/>
+    <SolidColorBrush x:Key="QuickDrawWindowTitleForeground" Color="#FFFFFFFF"/>
+    <SolidColorBrush x:Key="QuickDrawWindowDigitForeground" Color="#FFFFFFFF"/>
+
     <SolidColorBrush x:Key="SettingsPageForeground" Color="White" />
     <SolidColorBrush x:Key="SettingsPageAnnotationForeground" Opacity="1.0" Color="White" />
     <SolidColorBrush x:Key="SettingsPageBorderBrush" Opacity="1.0" Color="White" />

--- a/Ink Canvas/Resources/Styles/Light.xaml
+++ b/Ink Canvas/Resources/Styles/Light.xaml
@@ -10,6 +10,12 @@
     <SolidColorBrush x:Key="QuickDrawFloatingButtonBorderBrush" Color="#33000000"/>
     <SolidColorBrush x:Key="QuickDrawFloatingButtonIconForeground" Color="#FF000000"/>
 
+    <!-- 快抽窗口主题颜色 -->
+    <SolidColorBrush x:Key="QuickDrawWindowBackground" Color="#FFFFFFFF"/>
+    <SolidColorBrush x:Key="QuickDrawWindowBorderBrush" Color="#FFE0E0E0"/>
+    <SolidColorBrush x:Key="QuickDrawWindowTitleForeground" Color="#FF333333"/>
+    <SolidColorBrush x:Key="QuickDrawWindowDigitForeground" Color="#FF333333"/>
+
     <SolidColorBrush x:Key="SettingsPageForeground" Color="Black" />
     <SolidColorBrush x:Key="SettingsPageAnnotationForeground" Color="#666666" />
     <SolidColorBrush x:Key="SettingsPageBorderBrush" Opacity="0.8" Color="Black" />

--- a/Ink Canvas/Windows/QuickDrawWindow.xaml
+++ b/Ink Canvas/Windows/QuickDrawWindow.xaml
@@ -9,15 +9,6 @@
         Loaded="QuickDrawWindow_Loaded" Closing="Window_Closing" WindowStartupLocation="CenterScreen"
         Title="快抽窗口" Height="200" Width="400" Focusable="False" ShowInTaskbar="False">
 
-    <Window.Resources>
-        <ResourceDictionary>
-            <!-- 快抽窗口资源 -->
-            <SolidColorBrush x:Key="QuickDrawWindowBackground" Color="#1f1f1f"/>
-            <SolidColorBrush x:Key="QuickDrawWindowBorderBrush" Color="#E0E0E0"/>
-            <SolidColorBrush x:Key="QuickDrawWindowTitleForeground" Color="White"/>
-            <SolidColorBrush x:Key="QuickDrawWindowDigitForeground" Color="White"/>
-        </ResourceDictionary>
-    </Window.Resources>
 
     <Border Background="{DynamicResource QuickDrawWindowBackground}" 
             CornerRadius="15" 

--- a/Ink Canvas/Windows/QuickDrawWindow.xaml.cs
+++ b/Ink Canvas/Windows/QuickDrawWindow.xaml.cs
@@ -25,6 +25,7 @@ namespace Ink_Canvas
             InitializeComponent();
             this.Focusable = false;
             this.ShowInTaskbar = false;
+            RefreshTheme();
             InitializeSettings();
             LoadNamesFromFile();
             StartQuickDraw();
@@ -218,6 +219,22 @@ namespace Ink_Canvas
         {
             if (e.LeftButton == MouseButtonState.Pressed)
                 DragMove();
+        }
+
+        /// <summary>
+        /// 刷新主题，当主窗口主题切换时调用
+        /// </summary>
+        public void RefreshTheme()
+        {
+            try
+            {
+                ThemeHelper.ApplyTheme(this, MainWindow.Settings);
+                InvalidateVisual();
+            }
+            catch (Exception ex)
+            {
+                LogHelper.WriteLogToFile($"刷新快抽窗口主题出错: {ex.Message}", LogHelper.LogType.Error);
+            }
         }
 
 


### PR DESCRIPTION
### Motivation
- 让快抽窗口随应用的明暗主题切换，保持界面风格一致并便于统一维护资源。
- 将窗口内联颜色资源迁移到全局主题资源以避免重复并支持主题切换时统一刷新。

### Description
- 将 `QuickDrawWindow` 的颜色资源从窗口本地 `Window.Resources` 移除并添加到全局主题文件 `Resources/Styles/Light.xaml` 和 `Resources/Styles/Dark.xaml` 中（新增 `QuickDrawWindowBackground`、`QuickDrawWindowBorderBrush`、`QuickDrawWindowTitleForeground`、`QuickDrawWindowDigitForeground`）。
- 保持 XAML 中使用 `DynamicResource` 引用主题键，使窗口在资源变更时能动态取值（文件 `Windows/QuickDrawWindow.xaml`）。
- 在 `QuickDrawWindow` 构造函数中调用 `RefreshTheme()`，并新增 `RefreshTheme()` 方法，内部使用 `ThemeHelper.ApplyTheme(this, MainWindow.Settings)` 应用当前主题（文件 `Windows/QuickDrawWindow.xaml.cs`）。
- 在主窗口的主题刷新流程中加入对已打开 `QuickDrawWindow` 的刷新调用，使主题切换时同步更新（修改 `MainWindow_cs/MW_AutoTheme.cs` 的 `RefreshOtherWindowsTheme`）。

### Testing
- 使用 `python3 - <<'PY' ... ET.parse(...) ... PY` 对 `QuickDrawWindow.xaml`、`Resources/Styles/Light.xaml` 和 `Resources/Styles/Dark.xaml` 进行 XML 解析验证，结果均为 `OK`（文件均为合法 XML）。
- 试图运行 `dotnet build 'Ink Canvas.sln' --no-restore` 进行编译验证，但当前环境缺少 `dotnet` 命令导致无法完成构建检查。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb164ddc3c832993b178786518b17a)