### PR TITLE
Fix floating toolbar selection indicator position

### DIFF
--- a/Ink Canvas/MainWindow.xaml
+++ b/Ink Canvas/MainWindow.xaml
@@ -1140,7 +1140,7 @@
                                     <Border Name="FloatingbarSelectionBG" Visibility="Hidden" d:Visibility="Visible" Width="28" Height="34"
                                             Canvas.Left="28" Margin="0,-2,0,-2" Background="#153b82f6">
                                         <Canvas>
-                                            <Border Canvas.Bottom="0" Canvas.Left="8" Width="12" Height="2"
+                                            <Border Canvas.Bottom="2" Canvas.Left="8" Width="12" Height="2"
                                                     CornerRadius="1,1,0,0" Background="#2563eb" />
                                         </Canvas>
                                     </Border>


### PR DESCRIPTION
### Motivation
- The blue underline used to indicate the selected floating toolbar item was positioned too low and clipped, so move it up a bit to ensure it is fully visible.

### Description
- Adjusted the underline element in `Ink Canvas/MainWindow.xaml` by changing `Canvas.Bottom="0"` to `Canvas.Bottom="2"` for the inner `Border` inside `FloatingbarSelectionBG` so the indicator sits 2px higher.

### Testing
- Parsed `Ink Canvas/MainWindow.xaml` with `python` using `xml.etree.ElementTree` which reported the XAML is well-formed; `git diff --check` produced no issues; `dotnet --info` is not available in this environment so a full build/check was not run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc0d607b9c83298abdd1db6452dbba)