### PR TITLE
fix:Revert #470

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -227,28 +227,16 @@ jobs:
       - name: Restore Package 
         run: dotnet restore "Ink Canvas.sln" --locked-mode
       
-      - name: Publish with ReadyToRun (Release)
+      - name: Build the Solution (Release)
         env:
           DLASS_SENTRY_DSN: ${{ secrets.DLASS_SENTRY_DSN }}
         run: |
-          $platform = "${{ matrix.architecture }}"
-          if ($platform -eq "AnyCPU") {
-            $runtimeId = "win-x64"
-          } else {
-            $runtimeId = "win-x86"
-          }
-          dotnet publish "Ink Canvas/InkCanvasForClass.csproj" `
-            -c Release `
-            -r $runtimeId `
-            --self-contained true `
-            -p:Platform=$platform `
-            -p:GitFlow="Github Action" `
-            -o "Ink Canvas\bin\Release\$platform\net6.0-windows10.0.19041.0\publish"
+          msbuild /p:platform="${{ matrix.architecture }}" /p:configuration="Release" /p:GitFlow="Github Action" "Ink Canvas/InkCanvasForClass.csproj" /m /p:UseMultiToolTask=true /p:EnforceProcessCountAcrossBuilds=true /verbosity:minimal -maxcpucount /p:RunAnalyzers=false
 
       - name: Check if exe file is generated
         id: check-exe
         run: |
-          $exePath = "Ink Canvas\bin\Release\${{ matrix.architecture }}\net6.0-windows10.0.19041.0\publish\InkCanvasForClass.exe"
+          $exePath = "Ink Canvas\bin\Release\${{ matrix.architecture }}\net6.0-windows10.0.19041.0\InkCanvasForClass.exe"
           
           if (Test-Path $exePath) {
             echo "build_success=true" >> $env:GITHUB_OUTPUT
@@ -296,7 +284,7 @@ jobs:
           New-Item -ItemType Directory -Path "release" -Force
           
           # 复制发布文件（使用架构特定的路径）
-          Copy-Item "Ink Canvas\bin\Release\$architecture\net6.0-windows10.0.19041.0\publish\*" "release/" -Recurse -Force
+          Copy-Item "Ink Canvas\bin\Release\$architecture\net6.0-windows10.0.19041.0\*" "release/" -Recurse -Force
           
           # 创建压缩包
           Compress-Archive -Path "release/*" -DestinationPath $archiveName -Force

--- a/Ink Canvas/InkCanvasForClass.csproj
+++ b/Ink Canvas/InkCanvasForClass.csproj
@@ -74,9 +74,6 @@
     <PackageProjectUrl>https://inkcanvasforclass.github.io</PackageProjectUrl>
     <FileVersion>bundled</FileVersion>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
-    <PublishReadyToRun>true</PublishReadyToRun>
-    <PublishReadyToRunShowWarnings>true</PublishReadyToRunShowWarnings>
-    <PublishReadyToRunEmitSymbols>true</PublishReadyToRunEmitSymbols>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|ARM64'">
     <OutputPath>bin\$(Configuration)\$(Platform)\</OutputPath>


### PR DESCRIPTION
**This Reverts InkCanvasForClass/community#470**

根据github 相关文档，超过100MB的文件需要使用git lfs

而根据 https://docs.github.com/en/billing/concepts/product-billing/git-lfs#free-use-of-git-lfs 这会导致严重的发版储存问题最终导致`download`仓库爆炸

在此仍然感谢 @CreeperAWA 为此PR做出的贡献