### PR TITLE
Fix floating toolbar highlight clipping

### DIFF
--- a/Ink Canvas/MainWindow.xaml
+++ b/Ink Canvas/MainWindow.xaml
@@ -1135,12 +1135,12 @@
                             HorizontalAlignment="Left"
                             d:Background="Red" d:BorderBrush="Green">
                         <Viewbox Stretch="UniformToFill">
-                            <Grid Height="34">
+                            <Grid Height="31">
                                 <Canvas Name="FloatingbarSelectionBGCanvas" Margin="2,0,2,0">
                                     <Border Name="FloatingbarSelectionBG" Visibility="Hidden" d:Visibility="Visible" Width="28" Height="34"
                                             Canvas.Left="28" Margin="0,-2,0,-2" Background="#153b82f6">
                                         <Canvas>
-                                            <Border Canvas.Bottom="0" Canvas.Left="8" Width="12" Height="2"
+                                            <Border Canvas.Bottom="1" Canvas.Left="8" Width="12" Height="2"
                                                     CornerRadius="1,1,0,0" Background="#2563eb" />
                                         </Canvas>
                                     </Border>

--- a/Ink Canvas/MainWindow.xaml
+++ b/Ink Canvas/MainWindow.xaml
@@ -1135,12 +1135,12 @@
                             HorizontalAlignment="Left"
                             d:Background="Red" d:BorderBrush="Green">
                         <Viewbox Stretch="UniformToFill">
-                            <Grid Height="31">
+                            <Grid Height="34">
                                 <Canvas Name="FloatingbarSelectionBGCanvas" Margin="2,0,2,0">
                                     <Border Name="FloatingbarSelectionBG" Visibility="Hidden" d:Visibility="Visible" Width="28" Height="34"
                                             Canvas.Left="28" Margin="0,-2,0,-2" Background="#153b82f6">
                                         <Canvas>
-                                            <Border Canvas.Bottom="0" Canvas.Left="8" Width="12" Height="2"
+                                            <Border Canvas.Bottom="1" Canvas.Left="8" Width="12" Height="2"
                                                     CornerRadius="1,1,0,0" Background="#2563eb" />
                                         </Canvas>
                                     </Border>

--- a/Ink Canvas/MainWindow.xaml
+++ b/Ink Canvas/MainWindow.xaml
@@ -1140,7 +1140,7 @@
                                     <Border Name="FloatingbarSelectionBG" Visibility="Hidden" d:Visibility="Visible" Width="28" Height="34"
                                             Canvas.Left="28" Margin="0,-2,0,-2" Background="#153b82f6">
                                         <Canvas>
-                                            <Border Canvas.Bottom="1" Canvas.Left="8" Width="12" Height="2"
+                                            <Border Canvas.Bottom="0" Canvas.Left="8" Width="12" Height="2"
                                                     CornerRadius="1,1,0,0" Background="#2563eb" />
                                         </Canvas>
                                     </Border>


### PR DESCRIPTION
### Motivation
- The floating toolbar highlight (selected background and bottom underline) was being clipped inside the scaled toolbar, causing the bottom indicator to display partially off-screen.
- Restore the visual container size and nudge the underline so the selected-state highlight renders fully in the `Viewbox`-scaled floating bar.

### Description
- In `Ink Canvas/MainWindow.xaml` changed the floating-bar inner `Grid` height from `31` to `34` to restore the previous visual container height for the highlight area.
- In `Ink Canvas/MainWindow.xaml` adjusted the underline `Border` by setting `Canvas.Bottom` from `0` to `1` so the blue indicator is raised by 1px and no longer clipped.

### Testing
- Ran `git diff --check` with no whitespace or merge errors reported.
- Parsed `Ink Canvas/MainWindow.xaml` with `python3` using `xml.etree.ElementTree` which succeeded and confirmed well-formed XAML.
- `dotnet --info` was attempted but not available in the environment, so a full WPF build/test could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc664ebb8c8329b4fca636b92e176a)