### PR TITLE
feat(墨迹识别): 添加激进优化模式选项

### DIFF
--- a/Ink Canvas/MainWindow_cs/MW_SimulatePressure&InkToShape.cs
+++ b/Ink Canvas/MainWindow_cs/MW_SimulatePressure&InkToShape.cs
@@ -604,15 +604,25 @@ namespace Ink_Canvas
                 {
                     async Task InkToShapeProcessCoreAsync()
                     {
+                        CancellationToken token = default;
                         if (Settings.InkToShape.AggressiveOptimization)
                         {
                             _inkToShapeCancellation?.Cancel();
                             _inkToShapeCancellation = new CancellationTokenSource();
-                            var token = _inkToShapeCancellation.Token;
+                            token = _inkToShapeCancellation.Token;
+                        }
 
+                        if (token != default)
+                        {
                             await InkToShapeSerial.WaitAsync(token).ConfigureAwait(true);
+                        }
+                        else
+                        {
+                            await InkToShapeSerial.WaitAsync().ConfigureAwait(true);
+                        }
 
-                            newStrokes.Add(e.Stroke);
+                        try
+                        {
                             if (newStrokes.Count > 4) newStrokes.RemoveAt(0);
                             for (var i = 0; i < newStrokes.Count; i++)
                                 if (!inkCanvas.Strokes.Contains(newStrokes[i]))

--- a/Ink Canvas/MainWindow_cs/MW_SimulatePressure&InkToShape.cs
+++ b/Ink Canvas/MainWindow_cs/MW_SimulatePressure&InkToShape.cs
@@ -47,6 +47,9 @@ namespace Ink_Canvas
         /// <summary>串行执行墨迹转形状。WinRT 必须在 Dispatcher 上延后执行：若在 StrokeCollected（UI 线程）内对 WinRT 路径同步 GetResult()，AnalyzeAsync 延续再贴回 UI 时会死锁。</summary>
         private static readonly SemaphoreSlim InkToShapeSerial = new SemaphoreSlim(1, 1);
 
+        /// <summary>激进优化模式：用于取消积压的识别任务</summary>
+        private CancellationTokenSource _inkToShapeCancellation;
+
         /// <summary>
         /// 收笔后待参与「手写体字形替换」的最近笔迹（多笔一字/一词时由 WinRT InkAnalyzer 合并为 InkWord）。
         /// </summary>
@@ -601,9 +604,14 @@ namespace Ink_Canvas
                 {
                     async Task InkToShapeProcessCoreAsync()
                     {
-                        await InkToShapeSerial.WaitAsync().ConfigureAwait(true);
-                        try
+                        if (Settings.InkToShape.AggressiveOptimization)
                         {
+                            _inkToShapeCancellation?.Cancel();
+                            _inkToShapeCancellation = new CancellationTokenSource();
+                            var token = _inkToShapeCancellation.Token;
+
+                            await InkToShapeSerial.WaitAsync(token).ConfigureAwait(true);
+
                             newStrokes.Add(e.Stroke);
                             if (newStrokes.Count > 4) newStrokes.RemoveAt(0);
                             for (var i = 0; i < newStrokes.Count; i++)
@@ -614,32 +622,40 @@ namespace Ink_Canvas
                                 if (!inkCanvas.Strokes.Contains(circles[i].Stroke))
                                     circles.RemoveAt(i);
 
-                            // 处理矩形参考线系统
                             ProcessRectangleGuideLines(e.Stroke);
 
                             var shapeMode = ShapeRecognitionRouter.FromSettingsInt(Settings.InkToShape.ShapeRecognitionEngine);
-                            InkShapeRecognitionResult result = InkShapeRecognitionResult.Empty;
+                            InkShapeRecognitionResult result;
 
-                            if (ShapeRecognitionRouter.ResolveUseWinRt(shapeMode) && Helpers.WinRtInkShapeRecognizer.IsApiAvailable)
+                            try
                             {
-                                result = await ModernInkAnalyzer.AnalyzeAsync(newStrokes);
-                            }
-                            else
-                            {
-                                var strokeReco = new StrokeCollection();
-                                result = await InkRecognizeHelper.RecognizeShapeUnifiedAsync(newStrokes, shapeMode);
-                                for (var i = newStrokes.Count - 1; i >= 0; i--)
+                                if (ShapeRecognitionRouter.ResolveUseWinRt(shapeMode) && Helpers.WinRtInkShapeRecognizer.IsApiAvailable)
                                 {
-                                    strokeReco.Add(newStrokes[i]);
-                                    var newResult = await InkRecognizeHelper.RecognizeShapeUnifiedAsync(strokeReco, shapeMode);
-                                    if (newResult.IsSuccess &&
-                                        (newResult.ShapeName == "Circle" || newResult.ShapeName == "Ellipse"))
+                                    result = await ModernInkAnalyzer.AnalyzeAsync(newStrokes).ConfigureAwait(false);
+                                }
+                                else
+                                {
+                                    var strokeReco = new StrokeCollection();
+                                    result = await InkRecognizeHelper.RecognizeShapeUnifiedAsync(newStrokes, shapeMode).ConfigureAwait(false);
+                                    for (var i = newStrokes.Count - 1; i >= 0; i--)
                                     {
-                                        result = newResult;
-                                        break;
+                                        strokeReco.Add(newStrokes[i]);
+                                        var newResult = await InkRecognizeHelper.RecognizeShapeUnifiedAsync(strokeReco, shapeMode).ConfigureAwait(false);
+                                        if (newResult.IsSuccess &&
+                                            (newResult.ShapeName == "Circle" || newResult.ShapeName == "Ellipse"))
+                                        {
+                                            result = newResult;
+                                            break;
+                                        }
                                     }
                                 }
                             }
+                            catch (OperationCanceledException)
+                            {
+                                return;
+                            }
+
+                            if (token.IsCancellationRequested) return;
 
                             if (!result.IsSuccess)
                                 return;

--- a/Ink Canvas/Properties/Strings.en-US.resx
+++ b/Ink Canvas/Properties/Strings.en-US.resx
@@ -597,6 +597,12 @@
   <data name="InkRecog_FixEllipse" xml:space="preserve">
     <value>Correct circles and ellipses</value>
   </data>
+  <data name="InkRecog_AggressiveOptimization" xml:space="preserve">
+    <value>Aggressive optimization</value>
+  </data>
+  <data name="InkRecog_AggressiveOptimizationDesc" xml:space="preserve">
+    <value>When enabled, skips queued recognition tasks during fast writing and processes only the latest stroke to prevent lag</value>
+  </data>
   <data name="InkRecog_AutoStraightLine" xml:space="preserve">
     <value>Auto-straighten lines</value>
   </data>

--- a/Ink Canvas/Properties/Strings.resx
+++ b/Ink Canvas/Properties/Strings.resx
@@ -628,6 +628,12 @@
   <data name="InkRecog_FixEllipse" xml:space="preserve">
     <value>矫正手绘圆形与椭圆</value>
   </data>
+  <data name="InkRecog_AggressiveOptimization" xml:space="preserve">
+    <value>激进优化模式</value>
+  </data>
+  <data name="InkRecog_AggressiveOptimizationDesc" xml:space="preserve">
+    <value>启用后，快速书写时将跳过积压的识别任务，直接处理最新笔画，避免程序卡顿</value>
+  </data>
   <data name="InkRecog_AutoStraightLine" xml:space="preserve">
     <value>直线自动拉直</value>
   </data>

--- a/Ink Canvas/Resources/Settings.cs
+++ b/Ink Canvas/Resources/Settings.cs
@@ -831,6 +831,8 @@ namespace Ink_Canvas
         public bool EnableWinRtHandwritingStrokeBeautify { get; set; }
         [JsonProperty("handwritingCorrectionFontFamily")]
         public string HandwritingCorrectionFontFamily { get; set; } = "Ink Free,KaiTi,Segoe Script";
+        [JsonProperty("aggressiveOptimization")]
+        public bool AggressiveOptimization { get; set; }
     }
 
     public class RandSettings

--- a/Ink Canvas/Windows/SettingsViews/Pages/InkRecognitionPage.xaml
+++ b/Ink Canvas/Windows/SettingsViews/Pages/InkRecognitionPage.xaml
@@ -121,6 +121,15 @@
                         </ui:SettingsExpander.Items>
                     </ui:SettingsExpander>
 
+                    <controls:LabeledSettingsCard x:Name="CardAggressiveOptimization"
+                            Header="{i18n:I18n Key=InkRecog_AggressiveOptimization}"
+                            Description="{i18n:I18n Key=InkRecog_AggressiveOptimizationDesc}"
+                            ShowWhen="{Binding IsOn, ElementName=CardEnableInkToShape}"
+                            d:Visibility="Visible"
+                            Icon="{x:Static ui:SegoeFluentIcons.SpeedHigh}"
+                            SwitchName="ToggleSwitchAggressiveOptimization"
+                            Toggled="ToggleSwitchAggressiveOptimization_Toggled" />
+
                     <ui:SettingsExpander x:Name="ExpanderAutoStraightenLine"
                             Header="{i18n:I18n Key=InkRecog_AutoStraightLine}"
                             d:Visibility="Visible" d:IsExpanded="True">

--- a/Ink Canvas/Windows/SettingsViews/Pages/InkRecognitionPage.xaml.cs
+++ b/Ink Canvas/Windows/SettingsViews/Pages/InkRecognitionPage.xaml.cs
@@ -60,6 +60,7 @@ namespace Ink_Canvas.Windows.SettingsViews.Pages
                     ToggleCheckboxEnableInkToShapeRectangle.IsChecked = settings.InkToShape.IsInkToShapeRectangle;
                     ToggleCheckboxEnableInkToShapeRounded.IsChecked = settings.InkToShape.IsInkToShapeRounded;
                     LineStraightenSensitivitySlider.Value = settings.InkToShape.LineStraightenSensitivity;
+                    CardAggressiveOptimization.IsOn = settings.InkToShape.AggressiveOptimization;
                 }
 
                 if (settings.Canvas != null)
@@ -175,6 +176,13 @@ namespace Ink_Canvas.Windows.SettingsViews.Pages
         {
             if (!_isLoaded) return;
             SettingsManager.Settings.InkToShape.IsInkToShapeRounded = (bool)ToggleCheckboxEnableInkToShapeRounded.IsChecked;
+            SettingsManager.SaveSettingsToFile();
+        }
+
+        private void ToggleSwitchAggressiveOptimization_Toggled(object sender, RoutedEventArgs e)
+        {
+            if (!_isLoaded) return;
+            SettingsManager.Settings.InkToShape.AggressiveOptimization = CardAggressiveOptimization.IsOn;
             SettingsManager.SaveSettingsToFile();
         }
 


### PR DESCRIPTION
**未经实际测试**

在墨迹转形状功能中新增激进优化模式开关，当启用时跳过积压的识别任务直接处理最新笔画，避免快速书写时程序卡顿甚至误判假死。

---

我们的电脑用的32位WPS导致卡死了，墨迹闪烁甚至误判假死

这个会把积压的任务直接丢弃，所以加了设置项

我觉得画图频率应该不是很快，对跑的动的用户也无感