### PR TITLE
fix: ppt开始放映时性能优化

### DIFF
--- a/Ink Canvas/Helpers/PPTUIManager.cs
+++ b/Ink Canvas/Helpers/PPTUIManager.cs
@@ -76,12 +76,12 @@ namespace Ink_Canvas.Helpers
         /// </summary>
         public void UpdateSlideShowStatus(bool isInSlideShow, int currentSlide = 0, int totalSlides = 0)
         {
-            _mainWindow.IsInPptPresentationMode = isInSlideShow;
-
             void UpdateSlideShowStatusOnUi()
             {
                 try
                 {
+                    _mainWindow.IsInPptPresentationMode = isInSlideShow;
+
                     if (isInSlideShow)
                     {
                         // Old UI removed:                         _mainWindow.BtnPPTSlideShow.Visibility = Visibility.Collapsed;
@@ -150,7 +150,7 @@ namespace Ink_Canvas.Helpers
             }
             else
             {
-                _dispatcher.InvokeAsync(UpdateSlideShowStatusOnUi);
+                _dispatcher.Invoke(UpdateSlideShowStatusOnUi);
             }
         }
 

--- a/Ink Canvas/Helpers/PPTUIManager.cs
+++ b/Ink Canvas/Helpers/PPTUIManager.cs
@@ -76,14 +76,15 @@ namespace Ink_Canvas.Helpers
         /// </summary>
         public void UpdateSlideShowStatus(bool isInSlideShow, int currentSlide = 0, int totalSlides = 0)
         {
-            _dispatcher.InvokeAsync(() =>
+            _mainWindow.IsInPptPresentationMode = isInSlideShow;
+
+            void UpdateSlideShowStatusOnUi()
             {
                 try
                 {
                     if (isInSlideShow)
                     {
                         // Old UI removed:                         _mainWindow.BtnPPTSlideShow.Visibility = Visibility.Collapsed;
-                        _mainWindow.IsInPptPresentationMode = true;
                         _mainWindow.UpdateToolbarComponentVisibility();
 
                         // 同步页码到所有翻页条 + 兼容旧绑定的隐藏 placeholder
@@ -115,7 +116,6 @@ namespace Ink_Canvas.Helpers
                     else
                     {
                         // Old UI removed:                         _mainWindow.BtnPPTSlideShow.Visibility = Visibility.Visible;
-                        _mainWindow.IsInPptPresentationMode = false;
                         _mainWindow.UpdateToolbarComponentVisibility();
                         HideAllNavigationPanels();
                         _mainWindow.UpdatePPTTimeCapsuleVisibility();
@@ -142,7 +142,16 @@ namespace Ink_Canvas.Helpers
                 {
                     LogHelper.WriteLogToFile($"更新幻灯片放映状态UI失败: {ex}", LogHelper.LogType.Error);
                 }
-            });
+            }
+
+            if (_dispatcher.CheckAccess())
+            {
+                UpdateSlideShowStatusOnUi();
+            }
+            else
+            {
+                _dispatcher.InvokeAsync(UpdateSlideShowStatusOnUi);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
原来 UpdateSlideShowStatus(true, ...) 会把 IsInPptPresentationMode = true 放进 UI 调度队列里异步执行，但调用方马上会执行 CheckMainWindowVisibility()，因此在仅 PPT 模式下可能读到旧的 false，导致窗口不能立刻显示。