### PR TITLE
规避因错误导致的大量重复消息

### DIFF
--- a/Ink Canvas/Helpers/NotificationCenterService.cs
+++ b/Ink Canvas/Helpers/NotificationCenterService.cs
@@ -11,6 +11,13 @@ namespace Ink_Canvas.Helpers
         private static readonly List<NotificationMessage> Queue = new List<NotificationMessage>();
         private static readonly List<NotificationMessage> History = new List<NotificationMessage>();
         private static bool isShowing;
+        private struct JudgeRepeatMessageStruct
+        {
+            public string Title { get; set; }
+            public DateTime Time { get; set; }
+            public string Source { get; set; }
+        }
+        private static JudgeRepeatMessageStruct JudgeRepeatMessage = new JudgeRepeatMessageStruct();
 
         public static event Action<NotificationMessage> NotificationRequested;
 
@@ -39,6 +46,26 @@ namespace Ink_Canvas.Helpers
 
             lock (SyncRoot)
             {
+                ///<summary>
+                ///在一定时间内和前一条相同且来源一样就不重复显示
+                ///场景：教学课堂环境，插件可能因异常（如死循环、网络重连）高频推送相同通知。
+                ///策略：采用滑动窗口去重（2秒内）。若同一来源的相同标题持续出现，每次出现都刷新窗口起点，使通知彻底沉默，直到插件停止刷屏 2 秒以上。
+                ///效果：杜绝课堂被反复弹窗干扰，同时不影响正常间隔（> 2秒）的有效通知。
+                ///</summary>
+                if (!string.IsNullOrEmpty(message.Title) && JudgeRepeatMessage.Title!=null)
+                {
+                    TimeSpan interval = message.CreatedAt - JudgeRepeatMessage.Time;
+                    double TotalSeconds = interval.TotalSeconds;
+                    if(JudgeRepeatMessage.Title == message.Title && TotalSeconds<=2 && message.Source==JudgeRepeatMessage.Source)
+                    {
+                        JudgeRepeatMessage.Time = message.CreatedAt;
+                        return;
+                    }
+                    
+                }
+                JudgeRepeatMessage.Title = message.Title;
+                JudgeRepeatMessage.Time = message.CreatedAt;
+                JudgeRepeatMessage.Source = message.Source;
                 Queue.Add(message);
                 History.Insert(0, message);
                 if (History.Count > 100) History.RemoveRange(100, History.Count - 100);


### PR DESCRIPTION
*场景*：教学课堂环境，插件可能因异常（如死循环、网络重连）高频推送相同通知。
*策略*：采用滑动窗口去重（2秒内）。若同一来源的相同标题持续出现，每次出现都刷新窗口起点，使通知彻底沉默，直到插件停止刷屏 2 秒以上。
*效果*：杜绝课堂被反复弹窗干扰，同时不影响正常间隔（> 2秒）的有效通知。
>ps. 在代码中也留了个同样的描述方便理解，觉得不需要可以删