### PR TITLE
add: 快抽支持调用外部点名

### DIFF
--- a/Ink Canvas/Controls/QuickDrawFloatingButtonControl.xaml.cs
+++ b/Ink Canvas/Controls/QuickDrawFloatingButtonControl.xaml.cs
@@ -33,6 +33,10 @@ namespace Ink_Canvas.Controls
                 // 如果正在拖动，不触发点击事件
                 if (_isDragging) return;
 
+                if (MainWindow.Settings?.RandSettings?.QuickDrawExternalCaller == true &&
+                    QuickDrawWindow.TryLaunchExternalCaller())
+                    return;
+
                 // 打开快抽窗口
                 var quickDrawWindow = new QuickDrawWindow();
                 quickDrawWindow.ShowDialog();
@@ -145,4 +149,3 @@ namespace Ink_Canvas.Controls
         }
     }
 }
-

--- a/Ink Canvas/MainWindow.xaml.cs
+++ b/Ink Canvas/MainWindow.xaml.cs
@@ -3554,6 +3554,10 @@ namespace Ink_Canvas
                 if (Settings?.RandSettings?.EnableQuickDraw != true)
                     return;
 
+                if (Settings.RandSettings.QuickDrawExternalCaller &&
+                    QuickDrawWindow.TryLaunchExternalCaller())
+                    return;
+
                 var quickDrawWindow = new QuickDrawWindow();
                 quickDrawWindow.Owner = this;
                 quickDrawWindow.ShowDialog();

--- a/Ink Canvas/Properties/RandomStrings.Designer.cs
+++ b/Ink Canvas/Properties/RandomStrings.Designer.cs
@@ -327,6 +327,8 @@ namespace Ink_Canvas.Properties
 
         public static string Random_QuickDraw_WindowTitle => ResourceManager.GetString(nameof(Random_QuickDraw_WindowTitle), _resourceCulture);
 
+        public static string Random_QuickDraw_UseExternal => ResourceManager.GetString(nameof(Random_QuickDraw_UseExternal), _resourceCulture);
+
         public static string Random_QuickDraw_Title => ResourceManager.GetString(nameof(Random_QuickDraw_Title), _resourceCulture);
 
         public static string Random_Rand_ClickToImport => ResourceManager.GetString(nameof(Random_Rand_ClickToImport), _resourceCulture);

--- a/Ink Canvas/Properties/RandomStrings.en-US.resx
+++ b/Ink Canvas/Properties/RandomStrings.en-US.resx
@@ -480,6 +480,9 @@ If not installed, please download and install it from the official website. If a
   <data name="Random_AddIcon_SaveFailedFormat" xml:space="preserve">
     <value>Error saving icon: {0}</value>
   </data>
+  <data name="Random_QuickDraw_UseExternal" xml:space="preserve">
+    <value>Use selected external caller for quick draw</value>
+  </data>
   <data name="Random_QuickDraw_WindowTitle" xml:space="preserve">
     <value>Quick Draw</value>
   </data>

--- a/Ink Canvas/Properties/RandomStrings.resx
+++ b/Ink Canvas/Properties/RandomStrings.resx
@@ -480,6 +480,9 @@
   <data name="Random_AddIcon_SaveFailedFormat" xml:space="preserve">
     <value>保存图标时出错: {0}</value>
   </data>
+  <data name="Random_QuickDraw_UseExternal" xml:space="preserve">
+    <value>快抽调用所选外部点名</value>
+  </data>
   <data name="Random_QuickDraw_WindowTitle" xml:space="preserve">
     <value>快抽窗口</value>
   </data>

--- a/Ink Canvas/Properties/RandomStrings.zh-ME.resx
+++ b/Ink Canvas/Properties/RandomStrings.zh-ME.resx
@@ -480,6 +480,9 @@
   <data name="Random_AddIcon_SaveFailedFormat" xml:space="preserve">
     <value>保存图标翻车了: {0}</value>
   </data>
+  <data name="Random_QuickDraw_UseExternal" xml:space="preserve">
+    <value>快抽调用所选外部点名</value>
+  </data>
   <data name="Random_QuickDraw_WindowTitle" xml:space="preserve">
     <value>快抽窗口</value>
   </data>

--- a/Ink Canvas/Resources/Settings.cs
+++ b/Ink Canvas/Resources/Settings.cs
@@ -1546,6 +1546,8 @@ namespace Ink_Canvas
         public double MLAvoidanceWeight { get; set; } = 1.0;
         [JsonProperty("enableQuickDraw")]
         public bool EnableQuickDraw { get; set; } = true;
+        [JsonProperty("quickDrawExternalCaller")]
+        public bool QuickDrawExternalCaller { get; set; }
         [JsonProperty("nameRosters")]
         public List<NameRoster> NameRosters { get; set; } = new List<NameRoster>();
         [JsonProperty("selectedNameRosterGuid")]

--- a/Ink Canvas/Windows/QuickDrawWindow.xaml.cs
+++ b/Ink Canvas/Windows/QuickDrawWindow.xaml.cs
@@ -85,16 +85,6 @@ namespace Ink_Canvas
                     System.Threading.Thread.Sleep(100);
                     Application.Current.Dispatcher.Invoke(() =>
                     {
-                        // 若启用了快抽外部点名，则优先调用所选的外部点名器
-                        if (MainWindow.Settings?.RandSettings?.QuickDrawExternalCaller == true)
-                        {
-                            if (TryLaunchExternalCaller())
-                            {
-                                Close();
-                                return;
-                            }
-                        }
-
                         StartQuickDrawAnimation();
                     });
                 }).Start();
@@ -108,7 +98,7 @@ namespace Ink_Canvas
         /// <summary>
         /// 调用所选外部点名器，成功返回 true
         /// </summary>
-        private bool TryLaunchExternalCaller()
+        internal static bool TryLaunchExternalCaller()
         {
             try
             {

--- a/Ink Canvas/Windows/QuickDrawWindow.xaml.cs
+++ b/Ink Canvas/Windows/QuickDrawWindow.xaml.cs
@@ -85,6 +85,16 @@ namespace Ink_Canvas
                     System.Threading.Thread.Sleep(100);
                     Application.Current.Dispatcher.Invoke(() =>
                     {
+                        // 若启用了快抽外部点名，则优先调用所选的外部点名器
+                        if (MainWindow.Settings?.RandSettings?.QuickDrawExternalCaller == true)
+                        {
+                            if (TryLaunchExternalCaller())
+                            {
+                                Close();
+                                return;
+                            }
+                        }
+
                         StartQuickDrawAnimation();
                     });
                 }).Start();
@@ -92,6 +102,30 @@ namespace Ink_Canvas
             catch (Exception ex)
             {
                 LogHelper.WriteLogToFile($"开始快抽失败: {ex.Message}", LogHelper.LogType.Error);
+            }
+        }
+
+        /// <summary>
+        /// 调用所选外部点名器，成功返回 true
+        /// </summary>
+        private bool TryLaunchExternalCaller()
+        {
+            try
+            {
+                var protocols = ExternalCallerLauncher.GetProtocolsByType(MainWindow.Settings.RandSettings.ExternalCallerType);
+
+                if (!ExternalCallerLauncher.TryLaunch(protocols, out Exception lastException))
+                {
+                    throw lastException ?? new InvalidOperationException("external caller protocols are unavailable");
+                }
+
+                return true;
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(string.Format(Properties.RandomStrings.Random_RollCall_ExternalCallerFailedFormat, ex.Message), Properties.RandomStrings.Random_Error, MessageBoxButton.OK, MessageBoxImage.Error);
+                LogHelper.WriteLogToFile($"快抽外部点名调用失败: {ex.Message}", LogHelper.LogType.Error);
+                return false;
             }
         }
 

--- a/Ink Canvas/Windows/SettingsViews/Pages/RandomDrawPage.xaml
+++ b/Ink Canvas/Windows/SettingsViews/Pages/RandomDrawPage.xaml
@@ -47,6 +47,11 @@
                         IsOn="True"
                         Toggled="ToggleSwitchEnableQuickDraw_Toggled"/>
 
+                    <controls:LabeledSettingsCard x:Name="ToggleSwitchQuickDrawExternalCaller"
+                        Header="{x:Static props:RandomStrings.Random_QuickDraw_UseExternal}"
+                        IsOn="False"
+                        Toggled="ToggleSwitchQuickDrawExternalCaller_Toggled"/>
+
                     <controls:LabeledSettingsCard x:Name="ToggleSwitchExternalCaller"
                         Header="{x:Static props:RandomStrings.Random_UseExternal}"
                         IsOn="False"

--- a/Ink Canvas/Windows/SettingsViews/Pages/RandomDrawPage.xaml.cs
+++ b/Ink Canvas/Windows/SettingsViews/Pages/RandomDrawPage.xaml.cs
@@ -61,6 +61,7 @@ namespace Ink_Canvas.Windows.SettingsViews.Pages
             RandWindowOnceMaxStudentsSlider.Value = settings.RandSettings.RandWindowOnceMaxStudents;
             ToggleSwitchShowRandomAndSingleDraw.IsOn = settings.RandSettings.ShowRandomAndSingleDraw;
             ToggleSwitchEnableQuickDraw.IsOn = settings.RandSettings.EnableQuickDraw;
+            ToggleSwitchQuickDrawExternalCaller.IsOn = settings.RandSettings.QuickDrawExternalCaller;
             ToggleSwitchExternalCaller.IsOn = settings.RandSettings.DirectCallCiRand;
             ComboBoxExternalCallerType.SelectedIndex = settings.RandSettings.ExternalCallerType;
 
@@ -137,6 +138,13 @@ namespace Ink_Canvas.Windows.SettingsViews.Pages
             SettingsManager.SaveSettingsToFile();
 
             SettingsActionHub.OnEnableQuickDrawChanged();
+        }
+
+        private void ToggleSwitchQuickDrawExternalCaller_Toggled(object sender, RoutedEventArgs e)
+        {
+            if (!_isLoaded) return;
+            SettingsManager.Settings.RandSettings.QuickDrawExternalCaller = ToggleSwitchQuickDrawExternalCaller.IsOn;
+            SettingsManager.SaveSettingsToFile();
         }
 
         private void ToggleSwitchExternalCaller_Toggled(object sender, RoutedEventArgs e)

--- a/rules/Ink Canvas 设置完整目录.md
+++ b/rules/Ink Canvas 设置完整目录.md
@@ -494,6 +494,7 @@
 │   │   ├── LabeledSettingsCard: 显示编辑名单按钮 → ToggleSwitch
 │   │   ├── LabeledSettingsCard: 启用随机和单人抽取 → ToggleSwitch
 │   │   ├── LabeledSettingsCard: 启用快速抽取 → ToggleSwitch
+│   │   ├── LabeledSettingsCard: 快抽调用所选外部点名 → ToggleSwitch
 │   │   ├── LabeledSettingsCard: 使用外部调用 → ToggleSwitch
 │   │   ├── SettingsCard: 外部调用类型 → ComboBox
 │   │   ├── SettingsCard: 单次关闭延迟 → Slider


### PR DESCRIPTION
## 功能说明

- 为快抽新增独立的“调用所选外部点名”设置，默认关闭，不影响原有本地点名流程
- 根据现有 `ExternalCallerType` 调用 ClassIsland、SecRandom 或 NamePicker
- ClassIsland 优先使用 IslandCaller 的 `classisland://plugins/IslandCaller/Simple/1` 路由
- 外部调用失败时提示错误并回退到原本的快抽页面
- 在按钮和快捷键入口调用外部点名，避免先创建快抽窗口造成闪窗
- 补充默认、英文、zh-ME 三语资源及设置目录文档

## 验证

- `.NET Build & Package`：通过（AnyCPU / x86）
- `Lint`：通过
- `Sync net6 to net10`：通过
- `git diff --check`：通过
