### PR TITLE
fix: 插件外部dll授权弹窗逻辑优化

### DIFF
--- a/Ink Canvas/Plugins/PluginAuthorizationService.cs
+++ b/Ink Canvas/Plugins/PluginAuthorizationService.cs
@@ -4,17 +4,36 @@ using System.Collections.Generic;
 using System.IO;
 using System.Security.Cryptography;
 using System.Text.Json;
+using System.Threading;
 using System.Windows;
 
 namespace Ink_Canvas.Plugins
 {
     /// <summary>
     /// 管理插件加载外部程序集的用户授权。授权绑定插件 ID、程序集路径和 SHA-256。
+    /// <para>
+    /// 为避免同一插件的多个外部依赖在 ALC 递归解析期间连续弹出多个对话框
+    /// （以及并发解析时重复弹窗导致 UI 渲染错乱），本实现：
+    /// 1. 串行化所有授权请求（<see cref="_authorizationGate"/>）；
+    /// 2. 同一插件在一次加载会话内的首次决定（允许/拒绝）会被复用到该插件其余 DLL，
+    ///    仅当用户选择「允许」时才把每个 DLL 的路径 + SHA-256 持久化；
+    /// 3. 所有 MessageBox 调用强制切换到 UI 线程，避免在后台线程创建窗口。
+    /// </para>
     /// </summary>
     internal sealed class PluginAuthorizationService
     {
         private readonly string _filePath;
         private readonly Dictionary<string, string> _authorizations = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        // 串行化授权请求，确保同一时刻只有一个对话框。
+        private readonly SemaphoreSlim _authorizationGate = new SemaphoreSlim(1, 1);
+
+        // 会话级决定缓存：插件 Id -> 是否允许。一次加载会话内，同一插件的后续 DLL 复用首次决定，
+        // 避免逐个 DLL 弹窗。会话由 <see cref="BeginSession"/> / <see cref="EndSession"/> 控制。
+        private readonly Dictionary<string, bool> _sessionDecisions = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
+        // 同一插件待授权的 DLL 文件名集合，用于在单次确认对话框中向用户展示完整清单。
+        private readonly Dictionary<string, HashSet<string>> _sessionPendingFiles = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
+        private int _sessionDepth;
 
         public PluginAuthorizationService(string basePath)
         {
@@ -27,8 +46,11 @@ namespace Ink_Canvas.Plugins
             var key = CreateKey(plugin, assemblyPath);
             if (key == null || !File.Exists(assemblyPath)) return false;
             var hash = ComputeHash(assemblyPath);
-            return _authorizations.TryGetValue(key, out var authorizedHash)
-                && string.Equals(authorizedHash, hash, StringComparison.OrdinalIgnoreCase);
+            lock (_authorizations)
+            {
+                return _authorizations.TryGetValue(key, out var authorizedHash)
+                    && string.Equals(authorizedHash, hash, StringComparison.OrdinalIgnoreCase);
+            }
         }
 
         public bool RequestAuthorization(PluginInfo plugin, string assemblyPath)
@@ -41,22 +63,179 @@ namespace Ink_Canvas.Plugins
             return Request(plugin, assemblyPath, PluginStrings.Plugin_ExternalDllAuthorizationMessage);
         }
 
+        /// <summary>
+        /// 开始一次插件加载会话。会话内同一插件的多个外部 DLL 只弹一次确认框。
+        /// 嵌套调用通过引用计数支持。
+        /// </summary>
+        public void BeginSession()
+        {
+            Interlocked.Increment(ref _sessionDepth);
+        }
+
+        /// <summary>
+        /// 结束一次插件加载会话，清空会话级决定缓存。必须与 <see cref="BeginSession"/> 配对调用。
+        /// </summary>
+        public void EndSession()
+        {
+            if (Interlocked.Decrement(ref _sessionDepth) <= 0)
+            {
+                lock (_sessionDecisions)
+                {
+                    _sessionDecisions.Clear();
+                    _sessionPendingFiles.Clear();
+                }
+            }
+        }
+
         private bool Request(PluginInfo plugin, string assemblyPath, string messageTemplate)
         {
+            // 已持久化授权且哈希匹配时直接放行。
             if (IsAuthorized(plugin, assemblyPath)) return true;
+            if (plugin == null || string.IsNullOrEmpty(assemblyPath) || !File.Exists(assemblyPath)) return false;
+
+            var pluginId = plugin.Id;
+            var fileName = Path.GetFileName(assemblyPath);
+
+            // 会话内复用同一插件的决定。
+            if (_sessionDepth > 0)
+            {
+                lock (_sessionDecisions)
+                {
+                    if (_sessionDecisions.TryGetValue(pluginId, out var sessionAllowed))
+                    {
+                        if (!sessionAllowed) return false;
+                        // 用户已对该插件本次会话授权，持久化当前 DLL 的授权记录。
+                        PersistAuthorization(plugin, assemblyPath);
+                        return true;
+                    }
+
+                    // 收集待授权文件，稍后在单次对话框中一并向用户确认。
+                    if (!_sessionPendingFiles.ContainsKey(pluginId))
+                        _sessionPendingFiles[pluginId] = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                    _sessionPendingFiles[pluginId].Add(fileName);
+                }
+            }
+
+            // 串行化：等待其它授权请求完成，避免并发弹窗。
+            _authorizationGate.Wait();
+            try
+            {
+                // 再次检查持久化授权，可能在等待期间被其它线程写入。
+                if (IsAuthorized(plugin, assemblyPath)) return true;
+
+                // 会话内再次检查决定（可能在等待期间被同一插件的其它 DLL 触发并写入）。
+                if (_sessionDepth > 0)
+                {
+                    lock (_sessionDecisions)
+                    {
+                        if (_sessionDecisions.TryGetValue(pluginId, out var sessionAllowed))
+                        {
+                            if (!sessionAllowed) return false;
+                            PersistAuthorization(plugin, assemblyPath);
+                            return true;
+                        }
+                    }
+                }
+
+                // 在 UI 线程展示对话框。非 UI 线程直接调用 MessageBox.Show 会创建无 owner 窗口，
+                // 与启动期工具栏重建队列交错时导致焦点、渲染上下文异常。
+                bool allowed = ShowAuthorizationDialogOnUIThread(plugin, assemblyPath, messageTemplate, fileName);
+
+                if (_sessionDepth > 0)
+                {
+                    lock (_sessionDecisions)
+                    {
+                        _sessionDecisions[pluginId] = allowed;
+                    }
+                }
+
+                if (!allowed) return false;
+
+                PersistAuthorization(plugin, assemblyPath);
+                return true;
+            }
+            finally
+            {
+                _authorizationGate.Release();
+            }
+        }
+
+        private bool ShowAuthorizationDialogOnUIThread(PluginInfo plugin, string assemblyPath, string messageTemplate, string fileName)
+        {
+            var application = Application.Current;
+            if (application == null)
+            {
+                // 无 Application 上下文（极早期或设计期），保守拒绝。
+                return false;
+            }
+
+            var dispatcher = application.Dispatcher;
+            if (dispatcher == null) return false;
+
+            if (dispatcher.CheckAccess())
+            {
+                return ShowAuthorizationDialog(plugin, assemblyPath, messageTemplate, fileName);
+            }
+
+            bool result = false;
+            dispatcher.Invoke(() =>
+            {
+                result = ShowAuthorizationDialog(plugin, assemblyPath, messageTemplate, fileName);
+            });
+            return result;
+        }
+
+        private bool ShowAuthorizationDialog(PluginInfo plugin, string assemblyPath, string messageTemplate, string fileName)
+        {
+            // 会话内若有多个待确认文件，在消息中列出，让用户一次决定是否信任该插件的全部外部依赖。
+            string fileList = fileName;
+            if (_sessionDepth > 0)
+            {
+                lock (_sessionDecisions)
+                {
+                    if (_sessionPendingFiles.TryGetValue(plugin.Id, out var files) && files.Count > 1)
+                    {
+                        fileList = string.Join("\n  - ", files);
+                        fileList = "  - " + fileList;
+                    }
+                }
+            }
 
             var message = string.Format(messageTemplate,
-                plugin.Name, plugin.Author, Path.GetFileName(assemblyPath));
-            var result = iNKORE.UI.WPF.Modern.Controls.MessageBox.Show(
-                message,
-                PluginStrings.Plugin_ExternalDllAuthorizationTitle,
-                MessageBoxButton.YesNo,
-                MessageBoxImage.Warning);
-            if (result != MessageBoxResult.Yes) return false;
+                plugin.Name, plugin.Author, fileList);
 
-            _authorizations[CreateKey(plugin, assemblyPath)] = ComputeHash(assemblyPath);
+            var owner = Application.Current?.MainWindow;
+            MessageBoxResult result;
+            if (owner != null && owner.IsLoaded)
+            {
+                result = iNKORE.UI.WPF.Modern.Controls.MessageBox.Show(
+                    owner,
+                    message,
+                    PluginStrings.Plugin_ExternalDllAuthorizationTitle,
+                    MessageBoxButton.YesNo,
+                    MessageBoxImage.Warning);
+            }
+            else
+            {
+                result = iNKORE.UI.WPF.Modern.Controls.MessageBox.Show(
+                    message,
+                    PluginStrings.Plugin_ExternalDllAuthorizationTitle,
+                    MessageBoxButton.YesNo,
+                    MessageBoxImage.Warning);
+            }
+            return result == MessageBoxResult.Yes;
+        }
+
+        private void PersistAuthorization(PluginInfo plugin, string assemblyPath)
+        {
+            var key = CreateKey(plugin, assemblyPath);
+            if (key == null) return;
+            var hash = ComputeHash(assemblyPath);
+            lock (_authorizations)
+            {
+                _authorizations[key] = hash;
+            }
             Save();
-            return true;
         }
 
         private static string CreateKey(PluginInfo plugin, string assemblyPath)

--- a/Ink Canvas/Plugins/PluginManager.cs
+++ b/Ink Canvas/Plugins/PluginManager.cs
@@ -41,6 +41,11 @@ namespace Ink_Canvas.Plugins
         // 否则可回收 ALC 不会真正释放，热重载失效。
         private readonly Dictionary<string, PluginRegistrationScope> _registrationScopes
             = new Dictionary<string, PluginRegistrationScope>(StringComparer.OrdinalIgnoreCase);
+        // 批量加载标志：为 true 时插件注册工具栏项不会逐项排队重建，
+        // 而是设置 _boardToolbarRebuildPending，由加载完成后统一重建一次。
+        private bool _isLoadingBatch;
+        private bool _boardToolbarRebuildPending;
+
         // 卸载后仍在等待 GC 完成回收的 ALC 弱引用，用于校验是否真正卸载成功。
         private readonly Dictionary<string, WeakReference> _unloadingContexts
             = new Dictionary<string, WeakReference>(StringComparer.OrdinalIgnoreCase);
@@ -300,35 +305,49 @@ namespace Ink_Canvas.Plugins
                 var loadOrder = ResolveLoadOrder();
 
                 // 4. 按顺序加载插件
-                foreach (var pluginId in loadOrder)
+                // 包裹授权会话：同一插件的外部 DLL 只弹一次确认，避免逐个弹窗导致 UI 错乱。
+                _authorization?.BeginSession();
+                _isLoadingBatch = true;
+                try
                 {
-                    var info = _plugins.FirstOrDefault(p => p.Id == pluginId);
-                    if (info == null || info.LoadStatus != PluginLoadStatus.NotLoaded) continue;
+                    foreach (var pluginId in loadOrder)
+                    {
+                        var info = _plugins.FirstOrDefault(p => p.Id == pluginId);
+                        if (info == null || info.LoadStatus != PluginLoadStatus.NotLoaded) continue;
 
-                    // 跳过已禁用的插件
-                    if (IsPluginDisabled(pluginId))
-                    {
-                        info.LoadStatus = PluginLoadStatus.Disabled;
-                        Log(string.Format("Plugin {0} is disabled, skipping", info.Name));
-                        continue;
-                    }
+                        // 跳过已禁用的插件
+                        if (IsPluginDisabled(pluginId))
+                        {
+                            info.LoadStatus = PluginLoadStatus.Disabled;
+                            Log(string.Format("Plugin {0} is disabled, skipping", info.Name));
+                            continue;
+                        }
 
-                    try
-                    {
-                        LoadPlugin(info);
+                        try
+                        {
+                            LoadPlugin(info);
+                        }
+                        catch (Exception ex)
+                        {
+                            info.LoadStatus = PluginLoadStatus.Error;
+                            info.Exception = ex;
+                            LogError(string.Format("Failed to load plugin {0}", info.Name), ex);
+                        }
                     }
-                    catch (Exception ex)
-                    {
-                        info.LoadStatus = PluginLoadStatus.Error;
-                        info.Exception = ex;
-                        LogError(string.Format("Failed to load plugin {0}", info.Name), ex);
-                    }
+                }
+                finally
+                {
+                    _isLoadingBatch = false;
+                    _authorization?.EndSession();
                 }
 
                 _plugins.Sort((a, b) => a.Order.CompareTo(b.Order));
                 BuildServiceProvider();
                 _market?.RefreshMergedPlugins();
                 Log(string.Format("Plugin loading complete. Loaded {0} plugins", _plugins.Count(p => p.LoadStatus == PluginLoadStatus.Loaded)));
+
+                // 批量加载期间累积的白板工具栏重建请求，在此统一排队一次。
+                FlushPendingBoardToolbarRebuild();
             }
             catch (Exception ex)
             {
@@ -348,23 +367,36 @@ namespace Ink_Canvas.Plugins
             var installedIds = ProcessPluginPackages(approvedPackagePath, approvedPackageSha256);
             DiscoverPlugins();
             var loadOrder = ResolveLoadOrder();
-            foreach (var pluginId in loadOrder)
+            _authorization?.BeginSession();
+            _isLoadingBatch = true;
+            try
             {
-                var info = _plugins.FirstOrDefault(p => p.Id == pluginId && p.LoadStatus == PluginLoadStatus.NotLoaded);
-                if (info == null) continue;
-                try { LoadPlugin(info); }
-                catch (Exception ex)
+                foreach (var pluginId in loadOrder)
                 {
-                    info.LoadStatus = PluginLoadStatus.Error;
-                    info.Exception = ex;
-                    LogError(string.Format("Failed to load plugin {0}", info.Name), ex);
+                    var info = _plugins.FirstOrDefault(p => p.Id == pluginId && p.LoadStatus == PluginLoadStatus.NotLoaded);
+                    if (info == null) continue;
+                    try { LoadPlugin(info); }
+                    catch (Exception ex)
+                    {
+                        info.LoadStatus = PluginLoadStatus.Error;
+                        info.Exception = ex;
+                        LogError(string.Format("Failed to load plugin {0}", info.Name), ex);
+                    }
                 }
+            }
+            finally
+            {
+                _isLoadingBatch = false;
+                _authorization?.EndSession();
             }
             _plugins.Sort((a, b) => a.Order.CompareTo(b.Order));
             _market?.RefreshMergedPlugins();
 
             if (installedIds.Count > 0)
             {
+                // 批量加载期间累积的白板工具栏重建请求，在此统一排队一次。
+                FlushPendingBoardToolbarRebuild();
+
                 try
                 {
                     if (System.Windows.Application.Current?.MainWindow is Ink_Canvas.MainWindow mainWindow)
@@ -1894,6 +1926,29 @@ namespace Ink_Canvas.Plugins
             _serviceProvider = _serviceCollection.BuildServiceProvider();
         }
 
+        /// <summary>
+        /// 批量加载结束后，若有插件注册了白板工具栏项，排队一次 <see cref="MainWindow.RebuildBoardToolbar"/>。
+        /// 避免每个插件组件都单独排队重建，与授权弹窗嵌套消息循环交错时引发 UI 渲染错乱。
+        /// </summary>
+        private void FlushPendingBoardToolbarRebuild()
+        {
+            if (!_boardToolbarRebuildPending) return;
+            _boardToolbarRebuildPending = false;
+
+            try
+            {
+                if (Application.Current?.MainWindow is MainWindow mw)
+                {
+                    mw.Dispatcher.BeginInvoke(new Action(mw.RebuildBoardToolbar),
+                        System.Windows.Threading.DispatcherPriority.ApplicationIdle);
+                }
+            }
+            catch (Exception ex)
+            {
+                LogError("Failed to flush pending board toolbar rebuild", ex);
+            }
+        }
+
         public void RegisterToolbarItem(PluginToolbarItemInfo itemInfo)
         {
             if (itemInfo == null || string.IsNullOrEmpty(itemInfo.Id)) return;
@@ -1946,7 +2001,13 @@ namespace Ink_Canvas.Plugins
 
                 // 白板工具栏已构建时延迟重建以显示插件组件（在 Initialize 完成后执行，
                 // 避免 ViewFactory 依赖尚未初始化完成的插件状态）。
-                if (Application.Current?.MainWindow is MainWindow mw)
+                // 批量加载期间只标记，由加载完成后统一重建一次，避免每个组件都排队导致
+                // 重复销毁/创建控件与授权弹窗嵌套消息循环时交错引发 UI 渲染错乱。
+                if (_isLoadingBatch)
+                {
+                    _boardToolbarRebuildPending = true;
+                }
+                else if (Application.Current?.MainWindow is MainWindow mw)
                 {
                     mw.Dispatcher.BeginInvoke(new Action(mw.RebuildBoardToolbar),
                         System.Windows.Threading.DispatcherPriority.ApplicationIdle);


### PR DESCRIPTION
本pr代码为AI生成，我已初步审查确认没有问题。
以下为修复总结：

## 问题根因

外部插件引用多个 DLL 时，`PluginLoadContext` 的 `Load` / `LoadUnmanagedDll` 对每个依赖 DLL 逐个调用 `RequestExternalAuthorization`，而原实现存在三个问题：

1. **逐 DLL 弹窗**：同一插件的 N 个依赖就弹 N 次确认框
2. **无并发去重**：`_authorizations` 是普通 Dictionary，无锁、无 in-flight 去重，并发解析时同一 DLL 可能弹多个框
3. **非 UI 线程创建窗口**：`MessageBox.Show` 未切 Dispatcher，后台线程创建无 owner 窗口，与启动期工具栏重建队列交错导致渲染错乱
4. **工具栏重复重建**：`RegisterBoardToolbarItem` 每注册一个组件就排队一次 `RebuildBoardToolbar`，多个组件 = 多次清空/重建控件

## 修复内容

### [PluginAuthorizationService.cs](./Ink Canvas/Plugins/PluginAuthorizationService.cs)

- **串行锁** `SemaphoreSlim`：同一时刻只允许一个授权对话框
- **会话级决定缓存** `BeginSession/EndSession`：一次加载会话内，同一插件的首次"允许/拒绝"复用到该插件其余 DLL，不再逐个弹窗；多文件时在消息中列出完整清单
- **Dispatcher 切换**：所有 `MessageBox.Show` 强制切到 `Application.Current.Dispatcher`，并传入 `MainWindow` 作为 owner
- **持久化授权线程安全**：`_authorizations` 读写加锁

### [PluginManager.cs](./Ink Canvas/Plugins/PluginManager.cs)

- `LoadAllAsync` 和 `InstallPendingPackages` 加载循环外包裹 `BeginSession/EndSession`（finally 保证释放）
- 新增 `_isLoadingBatch` 标志：批量加载期间 `RegisterBoardToolbarItem` 不逐项排队重建，只设 `_boardToolbarRebuildPending`
- 新增 `FlushPendingBoardToolbarRebuild`：加载结束后统一排队一次 `RebuildBoardToolbar`