### PR TITLE
feat:白板缩略图拖曳&快抽结果滑动

### DIFF
--- a/Ink Canvas/MainWindow_cs/MW_BoardControls.cs
+++ b/Ink Canvas/MainWindow_cs/MW_BoardControls.cs
@@ -435,6 +435,32 @@ namespace Ink_Canvas
         /// - 处理右侧页面列表按钮点击：显示或隐藏右侧页面列表
         /// - 显示页面列表时会刷新列表内容并滚动到当前页面
         /// </remarks>
+        /// <summary>
+        /// 打开页列表面板前，按屏幕高度与页码按钮位置调整面板尺寸：
+        /// 目标约为屏幕高度的 60%（上限 640），面板底部钉在按钮上方，
+        /// 增加的高度通过上移面板吸收，顶部至少保留约 24px。
+        /// </summary>
+        private void EnsurePageListPanelHeight(Border panel, ScrollViewer scrollViewer, FrameworkElement anchorButton)
+        {
+            if (panel == null || scrollViewer == null || anchorButton == null) return;
+
+            var screenHeight = SystemParameters.WorkArea.Height;
+            var desiredHeight = Math.Min(screenHeight * 0.6, 640);
+
+            // 按钮顶部位置限制可上移空间（原始布局：-465 顶部边距 + 460 高度，
+            // 面板底部正好在按钮上方 5px，高度增量全部向上扩展）
+            var buttonTop = anchorButton.TransformToAncestor(this).Transform(new Point(0, 0)).Y;
+            var height = Math.Min(desiredHeight, Math.Max(320, buttonTop + 20));
+
+            scrollViewer.Height = height;
+
+            var baseMargin = panel.Tag is Thickness tag ? tag : panel.Margin;
+            panel.Margin = new Thickness(baseMargin.Left,
+                baseMargin.Top - (height - 460),
+                baseMargin.Right,
+                baseMargin.Bottom);
+        }
+
         private async void BtnWhiteBoardPageIndex_Click(object sender, EventArgs e)
         {
             var BtnLeftPageListWB = FindView("board.pageList.leftBtn") as Border;
@@ -461,6 +487,7 @@ namespace Ink_Canvas
                         RefreshBoothPageListView();
                     else
                         RefreshBlackBoardSidePageListView();
+                    EnsurePageListPanelHeight(BoardBorderLeftPageListView, BlackBoardLeftSidePageListScrollViewer, BtnLeftPageListWB);
                     AnimationsHelper.ShowWithSlideFromBottomAndFade(BoardBorderLeftPageListView);
                     await Task.Delay(1);
                     if (BlackBoardLeftSidePageListView != null)
@@ -492,6 +519,7 @@ namespace Ink_Canvas
                         RefreshBoothPageListView();
                     else
                         RefreshBlackBoardSidePageListView();
+                    EnsurePageListPanelHeight(BoardBorderRightPageListView, BlackBoardRightSidePageListScrollViewer, BtnRightPageListWB);
                     AnimationsHelper.ShowWithSlideFromBottomAndFade(BoardBorderRightPageListView);
                     await Task.Delay(1);
                     if (BlackBoardRightSidePageListView != null)

--- a/Ink Canvas/MainWindow_cs/MW_BoardToolbarHost.cs
+++ b/Ink Canvas/MainWindow_cs/MW_BoardToolbarHost.cs
@@ -8,8 +8,10 @@ using System.Collections.Generic;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
+using System.Windows.Data;
 using System.Windows.Input;
 using System.Windows.Media;
+using System.Windows.Media.Effects;
 using SegoeFluentIcons = iNKORE.UI.WPF.Modern.Common.IconKeys.SegoeFluentIcons;
 
 namespace Ink_Canvas
@@ -383,12 +385,20 @@ namespace Ink_Canvas
                     leftTouchStartY = pt.Y;
                     leftScrollStartOffset = leftScrollViewer.VerticalOffset;
                     leftScrollViewer.CaptureTouch(e.TouchDevice);
+                    // 长按缩略图进入拖拽排序候选（命中项才生效）
+                    TryBeginPageListDragCandidate(leftPageListView, e.GetTouchPoint(leftPageListView).Position, e.OriginalSource, requireHold: true);
                     e.Handled = true;
                 };
                 leftScrollViewer.TouchMove += (s, e) =>
                 {
                     if (leftIsTouching)
                     {
+                        // 拖拽排序（长按后拖动）优先：等待确认或拖拽中时吞掉事件，不滚动
+                        if (UpdatePageListDrag(leftPageListView, e.GetTouchPoint(leftPageListView).Position))
+                        {
+                            e.Handled = true;
+                            return;
+                        }
                         var pt = e.GetTouchPoint(leftScrollViewer).Position;
                         double deltaY = leftTouchStartY - pt.Y;
                         double deltaX = pt.X - leftTouchStartX;
@@ -401,7 +411,17 @@ namespace Ink_Canvas
                 };
                 leftScrollViewer.TouchUp += (s, e) =>
                 {
-                    if (leftIsTouching && !leftTouchDidScroll)
+                    var wasDragging = _pageListDragActive && _pageListDragListView == leftPageListView;
+                    if (wasDragging)
+                    {
+                        EndPageListDrag();
+                    }
+                    else if (_pageListDragCandidate && _pageListDragListView == leftPageListView)
+                    {
+                        CancelPageListDragCandidate();
+                    }
+
+                    if (leftIsTouching && !leftTouchDidScroll && !wasDragging)
                     {
                         var pt = e.GetTouchPoint(leftScrollViewer).Position;
                         double dx = pt.X - leftTouchStartX, dy = pt.Y - leftTouchStartY;
@@ -432,12 +452,20 @@ namespace Ink_Canvas
                     rightTouchStartY = pt.Y;
                     rightScrollStartOffset = rightScrollViewer.VerticalOffset;
                     rightScrollViewer.CaptureTouch(e.TouchDevice);
+                    // 长按缩略图进入拖拽排序候选（命中项才生效）
+                    TryBeginPageListDragCandidate(rightPageListView, e.GetTouchPoint(rightPageListView).Position, e.OriginalSource, requireHold: true);
                     e.Handled = true;
                 };
                 rightScrollViewer.TouchMove += (s, e) =>
                 {
                     if (rightIsTouching)
                     {
+                        // 拖拽排序（长按后拖动）优先：等待确认或拖拽中时吞掉事件，不滚动
+                        if (UpdatePageListDrag(rightPageListView, e.GetTouchPoint(rightPageListView).Position))
+                        {
+                            e.Handled = true;
+                            return;
+                        }
                         var pt = e.GetTouchPoint(rightScrollViewer).Position;
                         double deltaY = rightTouchStartY - pt.Y;
                         double deltaX = pt.X - rightTouchStartX;
@@ -450,7 +478,17 @@ namespace Ink_Canvas
                 };
                 rightScrollViewer.TouchUp += (s, e) =>
                 {
-                    if (rightIsTouching && !rightTouchDidScroll)
+                    var wasDragging = _pageListDragActive && _pageListDragListView == rightPageListView;
+                    if (wasDragging)
+                    {
+                        EndPageListDrag();
+                    }
+                    else if (_pageListDragCandidate && _pageListDragListView == rightPageListView)
+                    {
+                        CancelPageListDragCandidate();
+                    }
+
+                    if (rightIsTouching && !rightTouchDidScroll && !wasDragging)
                     {
                         var pt = e.GetTouchPoint(rightScrollViewer).Position;
                         double dx = pt.X - rightTouchStartX, dy = pt.Y - rightTouchStartY;
@@ -473,7 +511,8 @@ namespace Ink_Canvas
             double marginLeft, double marginTop, double marginRight, double marginBottom,
             string btnId)
         {
-            var itemTemplate = CreatePageListItemTemplate(mouseUpHandler);
+            // 选中条朝向屏幕中央：左侧列表的条在右，右侧列表的条在左
+            var itemTemplate = CreatePageListItemTemplate(mouseUpHandler, selectionBarOnLeft: listViewId != "board.pageList.left");
 
             var listView = new System.Windows.Controls.ListView
             {
@@ -488,6 +527,59 @@ namespace Ink_Canvas
             ScrollViewer.SetHorizontalScrollBarVisibility(listView, ScrollBarVisibility.Disabled);
             ScrollViewer.SetVerticalScrollBarVisibility(listView, ScrollBarVisibility.Disabled);
 
+            // 页面缩略图拖拽排序（鼠标/笔；触摸长按入口见 AttachPagePreviewTouchHandlers）
+            listView.PreviewMouseLeftButtonDown += PageList_PreviewMouseLeftButtonDown;
+            listView.PreviewMouseMove += PageList_PreviewMouseMove;
+            listView.PreviewMouseUp += PageList_PreviewMouseUp;
+            listView.LostMouseCapture += PageList_LostMouseCapture;
+            listView.SelectionChanged += PageList_SelectionChanged;
+
+            // 被拖项以半透明+阴影呈现"抬起"效果。
+            // 样式绑定到数据项的 IsDragging，集合移动/容器重建后跟随实例迁移，不会丢失。
+            // 注意：必须基于主题隐式样式继承（保留主题的选中/悬停视觉），
+            // 否则会回退到 WPF 默认容器白色 chrome。
+            var dragShadow = new DropShadowEffect
+            {
+                Color = Colors.Black,
+                BlurRadius = 10,
+                ShadowDepth = 2,
+                Direction = 270,
+                Opacity = 0.35
+            };
+            dragShadow.Freeze();
+            var dragTrigger = new DataTrigger { Binding = new Binding(nameof(PageListViewItem.IsDragging)), Value = true };
+            dragTrigger.Setters.Add(new Setter(UIElement.OpacityProperty, 0.7));
+            dragTrigger.Setters.Add(new Setter(UIElement.EffectProperty, dragShadow));
+            var containerStyle = new Style(typeof(ListViewItem));
+            if (listView.TryFindResource(typeof(ListViewItem)) is Style implicitItemStyle)
+                containerStyle.BasedOn = implicitItemStyle;
+            containerStyle.Setters.Add(new Setter(UIElement.OpacityProperty, 1.0));
+            // 兜底：即使主题隐式样式缺失，也保持容器无背景无边框（避免默认白色 chrome）
+            containerStyle.Setters.Add(new Setter(Control.BackgroundProperty, Brushes.Transparent));
+            containerStyle.Setters.Add(new Setter(Control.BorderThicknessProperty, new Thickness(0)));
+
+            // 自定义容器模板：剥离主题 ListViewItem 模板（其左侧选中指示条无法通过
+            // ListViewItemSelectionIndicatorVisualEnabled 资源可靠关闭，导致双蓝条），
+            // 选中态完全由缩略图卡片内的镜像小蓝条呈现；悬停反馈由下面的触发器补充。
+            var containerBorderFactory = new FrameworkElementFactory(typeof(Border));
+            containerBorderFactory.SetValue(Border.BackgroundProperty,
+                new TemplateBindingExtension(Control.BackgroundProperty));
+            var containerPresenterFactory = new FrameworkElementFactory(typeof(ContentPresenter));
+            containerPresenterFactory.SetValue(ContentPresenter.HorizontalAlignmentProperty, HorizontalAlignment.Stretch);
+            containerPresenterFactory.SetValue(ContentPresenter.VerticalAlignmentProperty, VerticalAlignment.Stretch);
+            containerBorderFactory.AppendChild(containerPresenterFactory);
+            containerStyle.Setters.Add(new Setter(Control.TemplateProperty, new ControlTemplate(typeof(ListViewItem))
+            {
+                VisualTree = containerBorderFactory
+            }));
+
+            containerStyle.Triggers.Add(dragTrigger);
+            var hoverTrigger = new Trigger { Property = UIElement.IsMouseOverProperty, Value = true };
+            hoverTrigger.Setters.Add(new Setter(Control.BackgroundProperty,
+                new SolidColorBrush(Color.FromArgb(0x14, 0, 0, 0))));
+            containerStyle.Triggers.Add(hoverTrigger);
+            listView.ItemContainerStyle = containerStyle;
+
             var scrollViewer = new ScrollViewer
             {
                 Name = scrollViewerId.Replace(".", "_"),
@@ -498,6 +590,25 @@ namespace Ink_Canvas
                 PanningMode = PanningMode.VerticalOnly,
                 IsManipulationEnabled = true
             };
+
+            // 拖拽排序的插入位置指示线：覆盖在列表上方，拖拽时实时定位到落点
+            var dragIndicator = new Border
+            {
+                Name = (listViewId + ".dragIndicator").Replace(".", "_"),
+                Height = 3,
+                CornerRadius = new CornerRadius(1.5),
+                Background = Application.Current.TryFindResource("AccentFillColorDefaultBrush") as Brush
+                             ?? SystemColors.HighlightBrush,
+                HorizontalAlignment = HorizontalAlignment.Stretch,
+                VerticalAlignment = VerticalAlignment.Top,
+                Margin = new Thickness(8, 0, 8, 0),
+                Visibility = Visibility.Collapsed,
+                IsHitTestVisible = false
+            };
+
+            var overlayGrid = new Grid();
+            overlayGrid.Children.Add(scrollViewer);
+            overlayGrid.Children.Add(dragIndicator);
 
             var border = new Border
             {
@@ -510,13 +621,16 @@ namespace Ink_Canvas
                 Opacity = 1,
                 BorderBrush = (Brush)Application.Current.TryFindResource("FloatingBarBorderBrush"),
                 BorderThickness = new Thickness(1),
-                Child = scrollViewer,
+                Child = overlayGrid,
                 Visibility = Visibility.Collapsed
             };
+            // 保存原始边距，供打开面板时按目标高度换算位置（见 EnsurePageListPanelHeight）
+            border.Tag = new Thickness(marginLeft, marginTop, marginRight, marginBottom);
 
             RegisterView(borderId, border);
             RegisterView(listViewId, listView);
             RegisterView(scrollViewerId, scrollViewer);
+            RegisterView(listViewId + ".dragIndicator", dragIndicator);
 
             var btn = FindView(btnId) as Border;
             if (btn != null)
@@ -532,7 +646,7 @@ namespace Ink_Canvas
             }
         }
 
-        private DataTemplate CreatePageListItemTemplate(MouseButtonEventHandler mouseUpHandler)
+        private DataTemplate CreatePageListItemTemplate(MouseButtonEventHandler mouseUpHandler, bool selectionBarOnLeft)
         {
             var template = new DataTemplate();
 
@@ -543,6 +657,7 @@ namespace Ink_Canvas
             var itemBorderFactory = new FrameworkElementFactory(typeof(Border));
             itemBorderFactory.SetValue(Border.MarginProperty, new Thickness(0, 4, 0, 0));
             itemBorderFactory.SetValue(Border.WidthProperty, 160.0);
+            itemBorderFactory.SetValue(Border.CornerRadiusProperty, new CornerRadius(4));
             itemBorderFactory.SetResourceReference(Border.BackgroundProperty, "FloatingBarBackgroundBrush");
             itemBorderFactory.SetResourceReference(Border.BorderBrushProperty, "FloatingBarBorderBrush");
             itemBorderFactory.SetValue(Border.BorderThicknessProperty, new Thickness(1));
@@ -551,8 +666,27 @@ namespace Ink_Canvas
 
             var viewboxFactory = new FrameworkElementFactory(typeof(Viewbox));
             viewboxFactory.SetValue(Viewbox.WidthProperty, 160.0);
-            viewboxFactory.SetValue(Viewbox.HeightProperty, 120.0);
             viewboxFactory.SetValue(Viewbox.StretchProperty, Stretch.Uniform);
+
+            // 高度与圆角裁剪都实时跟随画布实际宽高比（MultiBinding + 转换器）：
+            // 预览始终精确填满卡片，任何比例下都不存在留白边条
+            var heightBinding = new MultiBinding
+            {
+                Converter = new WhiteboardThumbnailAspectConverter(),
+                ConverterParameter = "Height"
+            };
+            heightBinding.Bindings.Add(new Binding("ActualWidth") { Source = inkCanvas });
+            heightBinding.Bindings.Add(new Binding("ActualHeight") { Source = inkCanvas });
+            viewboxFactory.SetBinding(Viewbox.HeightProperty, heightBinding);
+
+            var clipBinding = new MultiBinding
+            {
+                Converter = new WhiteboardThumbnailAspectConverter(),
+                ConverterParameter = "Clip"
+            };
+            clipBinding.Bindings.Add(new Binding("ActualWidth") { Source = inkCanvas });
+            clipBinding.Bindings.Add(new Binding("ActualHeight") { Source = inkCanvas });
+            viewboxFactory.SetBinding(UIElement.ClipProperty, clipBinding);
 
             // Viewbox 是 Decorator，只能有一个子级。用 Grid 作为容器，叠加 InkCanvas/Image/TextBlock
             // 三个元素，通过 Visibility 绑定互斥显示：
@@ -651,15 +785,58 @@ namespace Ink_Canvas
                 SegoeFluentIcons.Delete);
             deleteBtnFactory.AppendChild(fontIconFactory);
 
+            // 选中小蓝条：朝向屏幕中央——左侧控件弹出的列表条在右，右侧控件弹出的条在左
+            var selectionBarFactory = new FrameworkElementFactory(typeof(Border));
+            selectionBarFactory.SetValue(Border.WidthProperty, 3.0);
+            selectionBarFactory.SetValue(Border.CornerRadiusProperty, new CornerRadius(1.5));
+            selectionBarFactory.SetValue(Border.VerticalAlignmentProperty, VerticalAlignment.Stretch);
+            selectionBarFactory.SetValue(Border.HorizontalAlignmentProperty,
+                selectionBarOnLeft ? HorizontalAlignment.Left : HorizontalAlignment.Right);
+            selectionBarFactory.SetValue(Border.MarginProperty,
+                selectionBarOnLeft ? new Thickness(3, 8, 0, 8) : new Thickness(0, 8, 3, 8));
+            selectionBarFactory.SetValue(Border.BackgroundProperty,
+                Application.Current.TryFindResource("AccentFillColorDefaultBrush") as Brush
+                ?? SystemColors.HighlightBrush);
+            selectionBarFactory.SetValue(Border.IsHitTestVisibleProperty, false);
+            selectionBarFactory.SetBinding(UIElement.VisibilityProperty, new Binding("IsSelected") { Converter = boolToVis });
+
             gridFactory.AppendChild(viewboxFactory);
             gridFactory.AppendChild(indexBorderFactory);
             gridFactory.AppendChild(deleteBtnFactory);
+            gridFactory.AppendChild(selectionBarFactory);
 
             itemBorderFactory.AppendChild(gridFactory);
             outerStackFactory.AppendChild(itemBorderFactory);
             template.VisualTree = outerStackFactory;
 
             return template;
+        }
+
+        /// <summary>
+        /// 按画布实际宽高比计算缩略图尺寸（160 宽，高 80~120 夹紧）或同尺寸圆角裁剪。
+        /// 绑定到画布 ActualWidth/ActualHeight，页面预览实时精确填满卡片，
+        /// 任何比例下都不留白边；画布尺寸未就绪时回退 120（4:3）。
+        /// </summary>
+        private sealed class WhiteboardThumbnailAspectConverter : IMultiValueConverter
+        {
+            public object Convert(object[] values, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+            {
+                var width = values != null && values.Length > 0 && values[0] is double w ? w : 0;
+                var height = values != null && values.Length > 1 && values[1] is double h ? h : 0;
+
+                double thumbnailHeight = 120;
+                if (width > 1 && height > 1)
+                    thumbnailHeight = Math.Max(80, Math.Min(120, 160.0 * height / width));
+
+                if (parameter is string p && p == "Clip")
+                    return new RectangleGeometry(new Rect(0, 0, 160, thumbnailHeight), 4, 4);
+                return thumbnailHeight;
+            }
+
+            public object[] ConvertBack(object value, Type[] targetTypes, object parameter, System.Globalization.CultureInfo culture)
+            {
+                throw new NotSupportedException();
+            }
         }
     }
 }

--- a/Ink Canvas/MainWindow_cs/MW_PageListView.cs
+++ b/Ink Canvas/MainWindow_cs/MW_PageListView.cs
@@ -1,6 +1,8 @@
 using Ink_Canvas.Helpers;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.ComponentModel;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
@@ -12,8 +14,41 @@ namespace Ink_Canvas
 {
     public partial class MainWindow : Ink_Canvas.Helpers.PerformanceTransparentWin
     {
-        private class PageListViewItem
+        private class PageListViewItem : INotifyPropertyChanged
         {
+            public event PropertyChangedEventHandler PropertyChanged;
+
+            private bool _isDragging;
+            private bool _isSelected;
+
+            /// <summary>该项是否正被拖拽（用于缩略图列表的"抬起"样式）。</summary>
+            public bool IsDragging
+            {
+                get => _isDragging;
+                set
+                {
+                    if (_isDragging == value) return;
+                    _isDragging = value;
+                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsDragging)));
+                }
+            }
+
+            /// <summary>
+            /// 该项是否为当前页。选中态由模板中的小蓝条呈现；
+            /// 左侧列表的蓝条在条目右侧、右侧列表的蓝条在条目左侧（均朝向屏幕中央），
+            /// 左右列表共用同一数据集合，标记天然同步。
+            /// </summary>
+            public bool IsSelected
+            {
+                get => _isSelected;
+                set
+                {
+                    if (_isSelected == value) return;
+                    _isSelected = value;
+                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsSelected)));
+                }
+            }
+
             public int Index { get; set; }
             public StrokeCollection Strokes { get; set; }
 
@@ -448,5 +483,423 @@ namespace Ink_Canvas
 
             DeleteWhiteBoardPageByIndex(item.Index);
         }
+
+        #region 页面缩略图拖拽排序
+
+        /// <summary>拖拽排序是否已越过阈值真正开始。</summary>
+        private bool _pageListDragActive;
+
+        /// <summary>是否处于拖拽候选（已按下，等待越过阈值/长按确认）。</summary>
+        private bool _pageListDragCandidate;
+
+        private ListView _pageListDragListView;
+        private ScrollViewer _pageListDragScrollViewer;
+
+        /// <summary>拖拽起始项在集合中的索引（0-based，拖拽过程中保持不变）。</summary>
+        private int _pageListDragFromIndex = -1;
+
+        /// <summary>被拖项当前的集合索引（随实时移动更新）。</summary>
+        private int _pageListDragCurrentIndex = -1;
+
+        /// <summary>被拖项的实例（高亮状态跟随实例迁移，容器重建不丢失）。</summary>
+        private PageListViewItem _pageListDragItem;
+
+        /// <summary>被拖项的容器与其内容（拖拽期间跟随指针平移的是内容，容器布局保持不动）。</summary>
+        private ListViewItem _pageListDragContainer;
+        private UIElement _pageListDragContainerContent;
+        private TranslateTransform _pageListDragTranslate;
+
+        /// <summary>被拖项在列表坐标系中的布局中心 Y（拖拽期间集合不动，此值稳定）。</summary>
+        private double _pageListDragContainerCenterY;
+
+        /// <summary>插入位置指示线（仅活动列表显示）。</summary>
+        private Border _pageListDragIndicator;
+
+        private Point _pageListDragStartPosition;
+        private long _pageListDragCandidateStartTicks;
+        private bool _pageListDragRequiresHold;
+
+        /// <summary>鼠标/笔按下后移动超过该距离即开始拖拽。</summary>
+        private const double PageListDragThresholdPx = 8;
+
+        /// <summary>触摸需按住该时长确认拖拽（避免与列表滚动冲突）。</summary>
+        private const long PageListDragTouchHoldTicks = 450 * TimeSpan.TicksPerMillisecond;
+
+        /// <summary>
+        /// 在页面缩略图项上按下时记录拖拽候选。
+        /// 命中删除按钮、视频展台虚拟分页或仅一页时不进入候选。
+        /// </summary>
+        private bool TryBeginPageListDragCandidate(ListView listView, Point positionInList, object originalSource, bool requireHold)
+        {
+            if (_pageListDragActive || _isVideoPresenterSpecialMode || WhiteboardTotalCount < 2)
+                return false;
+
+            // 删除按钮上的按下不进入拖拽，保留按钮点击语义
+            if (FindAncestorOfType<Button>(originalSource as DependencyObject) != null)
+                return false;
+
+            var container = HitTestPageListViewItem(listView, positionInList);
+            if (container == null) return false;
+            var index = listView.ItemContainerGenerator.IndexFromContainer(container);
+            if (index < 0) return false;
+            if (!(listView.ItemContainerGenerator.ItemFromContainer(container) is PageListViewItem item)) return false;
+
+            _pageListDragCandidate = true;
+            _pageListDragListView = listView;
+            _pageListDragScrollViewer = FindAncestorOfType<ScrollViewer>(listView);
+            _pageListDragFromIndex = index;
+            _pageListDragCurrentIndex = index;
+            _pageListDragItem = item;
+            _pageListDragStartPosition = positionInList;
+            _pageListDragCandidateStartTicks = Environment.TickCount64;
+            _pageListDragRequiresHold = requireHold;
+            return true;
+        }
+
+        private static ListViewItem HitTestPageListViewItem(ListView listView, Point positionInList)
+        {
+            var hit = VisualTreeHelper.HitTest(listView, positionInList);
+            if (hit?.VisualHit == null) return null;
+            return FindAncestorOfType<ListViewItem>(hit.VisualHit);
+        }
+
+        /// <summary>
+        /// 移动事件驱动：等待越过阈值/长按确认后进入拖拽；拖拽中被拖项跟随指针、
+        /// 插入指示线标记落点（集合保持不动，松手时一次性移动）。
+        /// 返回 true 表示本次事件已被拖拽流程消费（触摸调用方应跳过滚动逻辑）。
+        /// </summary>
+        private bool UpdatePageListDrag(ListView listView, Point positionInList)
+        {
+            if (!_pageListDragCandidate || _pageListDragListView != listView) return false;
+
+            if (!_pageListDragActive)
+            {
+                var withinThreshold = Math.Abs(positionInList.Y - _pageListDragStartPosition.Y) <= PageListDragThresholdPx;
+
+                if (_pageListDragRequiresHold)
+                {
+                    // 长按确认前移动过大：取消候选，交还滚动
+                    if (!withinThreshold)
+                    {
+                        CancelPageListDragCandidate();
+                        return false;
+                    }
+                    if (Environment.TickCount64 - _pageListDragCandidateStartTicks < PageListDragTouchHoldTicks)
+                        return true;
+                }
+                else if (withinThreshold)
+                {
+                    return true;
+                }
+
+                _pageListDragActive = true;
+                BeginPageListDragVisual(listView);
+            }
+
+            AutoScrollPageListDuringDrag(positionInList);
+            UpdatePageListDragVisual(listView, positionInList);
+            return true;
+        }
+
+        /// <summary>进入拖拽：点亮被拖项"抬起"样式并让它从此刻起跟随指针。</summary>
+        private void BeginPageListDragVisual(ListView listView)
+        {
+            SetPageListDragItemHighlight(true);
+
+            _pageListDragContainer = listView.ItemContainerGenerator.ContainerFromIndex(_pageListDragFromIndex) as ListViewItem;
+            if (_pageListDragContainer != null)
+            {
+                _pageListDragContainerCenterY = _pageListDragContainer.TransformToVisual(listView)
+                    .Transform(new Point(0, _pageListDragContainer.ActualHeight / 2.0)).Y;
+
+                // 平移施加在容器的内容上（容器自身布局不动），滚动/坐标换算保持稳定
+                _pageListDragContainerContent = VisualTreeHelper.GetChildrenCount(_pageListDragContainer) > 0
+                    ? VisualTreeHelper.GetChild(_pageListDragContainer, 0) as UIElement
+                    : null;
+                if (_pageListDragContainerContent != null)
+                {
+                    _pageListDragTranslate = new TranslateTransform();
+                    var group = new TransformGroup();
+                    group.Children.Add(new ScaleTransform(1.03, 1.03));
+                    group.Children.Add(_pageListDragTranslate);
+                    _pageListDragContainerContent.RenderTransformOrigin = new Point(0.5, 0.5);
+                    _pageListDragContainerContent.RenderTransform = group;
+                }
+
+                Panel.SetZIndex(_pageListDragContainer, 10);
+            }
+
+            // 指示线只在用户拖拽的这一侧列表显示
+            _pageListDragIndicator = FindView("board.pageList.left") == listView
+                ? FindView("board.pageList.left.dragIndicator") as Border
+                : FindView("board.pageList.right.dragIndicator") as Border;
+        }
+
+        /// <summary>拖拽移动：被拖项跟随指针；指示线标记落点（k&lt;起点在其上方，k&gt;起点在其下方）。</summary>
+        private void UpdatePageListDragVisual(ListView listView, Point positionInList)
+        {
+            if (_pageListDragTranslate != null)
+                _pageListDragTranslate.Y = positionInList.Y - _pageListDragContainerCenterY;
+
+            _pageListDragCurrentIndex = ComputePageListDragTargetIndex(listView, positionInList);
+
+            if (_pageListDragIndicator == null) return;
+
+            // 落点未变时隐藏指示线
+            if (_pageListDragCurrentIndex == _pageListDragFromIndex)
+            {
+                _pageListDragIndicator.Visibility = Visibility.Collapsed;
+                return;
+            }
+
+            var anchorContainer = listView.ItemContainerGenerator.ContainerFromIndex(_pageListDragCurrentIndex) as ListViewItem;
+            if (anchorContainer == null)
+            {
+                _pageListDragIndicator.Visibility = Visibility.Collapsed;
+                return;
+            }
+
+            // 向上拖：线画在目标项上边缘；向下拖：画在目标项下边缘（含"放最后一位"）
+            var anchorPoint = new Point(0, _pageListDragCurrentIndex < _pageListDragFromIndex
+                ? 0
+                : anchorContainer.ActualHeight);
+            var y = anchorContainer.TransformToVisual(_pageListDragIndicator.Parent as Visual)
+                .Transform(anchorPoint).Y;
+
+            _pageListDragIndicator.Margin = new Thickness(8, y - 1.5, 8, 0);
+            _pageListDragIndicator.Visibility = Visibility.Visible;
+        }
+
+        /// <summary>拖拽接近列表上下边缘时自动滚动。</summary>
+        private void AutoScrollPageListDuringDrag(Point positionInList)
+        {
+            var scrollViewer = _pageListDragScrollViewer;
+            if (scrollViewer == null) return;
+
+            var posInScroll = _pageListDragListView.TransformToVisual(scrollViewer).Transform(positionInList);
+            const double edge = 24;
+            if (posInScroll.Y < edge) scrollViewer.LineUp();
+            else if (posInScroll.Y > scrollViewer.ActualHeight - edge) scrollViewer.LineDown();
+        }
+
+        /// <summary>
+        /// 根据指针位置计算被拖项的插入位置（0-based）。
+        /// 统计中点位于指针上方的其余项数量即为最终落点：被拖项自身被排除在计数外，
+        /// 无需再作偏移修正（额外减一会导致任何页都无法落到最后一位）。
+        /// </summary>
+        private int ComputePageListDragTargetIndex(ListView listView, Point positionInList)
+        {
+            var count = blackBoardSidePageListViewObservableCollection.Count;
+            var target = 0;
+            for (var i = 0; i < count; i++)
+            {
+                if (i == _pageListDragCurrentIndex) continue;
+                var container = listView.ItemContainerGenerator.ContainerFromIndex(i) as ListViewItem;
+                if (container == null) continue;
+                var midY = container.TransformToVisual(listView)
+                    .Transform(new Point(0, container.ActualHeight / 2.0)).Y;
+                if (positionInList.Y > midY) target++;
+            }
+            return Math.Max(0, Math.Min(count - 1, target));
+        }
+
+        /// <summary>
+        /// 结束拖拽：按落点一次性移动集合，把第 fromPage 页的数据搬移到第 toPage 页，
+        /// 页号重排并刷新列表。被拖页是当前页时先保存未提交墨迹，恢复后页号跟随；
+        /// 否则仅搬移快照数组、画布不动。
+        /// </summary>
+        private void EndPageListDrag()
+        {
+            if (!_pageListDragActive)
+            {
+                CancelPageListDragCandidate();
+                return;
+            }
+
+            _pageListDragActive = false;
+            _pageListDragCandidate = false;
+
+            var fromPage = _pageListDragFromIndex + 1;
+            var toPage = _pageListDragCurrentIndex + 1;
+
+            try
+            {
+                if (fromPage != toPage
+                    && fromPage >= 1 && fromPage <= WhiteboardTotalCount
+                    && toPage >= 1 && toPage <= WhiteboardTotalCount)
+                {
+                    // 集合按最终落点一次性移动（拖拽期间集合未动）
+                    blackBoardSidePageListViewObservableCollection.Move(_pageListDragFromIndex, _pageListDragCurrentIndex);
+
+                    if (CurrentWhiteboardIndex == fromPage)
+                    {
+                        // 当前页参与搬移：先落盘未保存的墨迹，页号跟随被拖页
+                        VideoPresenter_BeforePageLeave();
+                        PauseAllCanvasMediaPlayback();
+                        SaveStrokes();
+                        ClearStrokes(true);
+
+                        MoveWhiteboardPageData(fromPage, toPage);
+
+                        CurrentWhiteboardIndex = toPage;
+
+                        RestoreStrokes();
+                        VideoPresenter_OnPageChanged();
+                    }
+                    else
+                    {
+                        // 其他页搬移：当前画布不动，仅重排快照与页号
+                        MoveWhiteboardPageData(fromPage, toPage);
+
+                        if (fromPage < toPage && CurrentWhiteboardIndex > fromPage && CurrentWhiteboardIndex <= toPage)
+                            CurrentWhiteboardIndex--;
+                        else if (toPage < fromPage && CurrentWhiteboardIndex >= toPage && CurrentWhiteboardIndex < fromPage)
+                            CurrentWhiteboardIndex++;
+                    }
+
+                    UpdateIndexInfoDisplay();
+                    RefreshBlackBoardSidePageListView();
+                }
+            }
+            catch (Exception ex)
+            {
+                LogHelper.WriteLogToFile($"页面拖拽排序失败: {ex.Message}", LogHelper.LogType.Error);
+            }
+            finally
+            {
+                CancelPageListDragCandidate();
+            }
+        }
+
+        /// <summary>取消拖拽候选并清空状态（含被拖项视觉与插入指示线的还原）。</summary>
+        private void CancelPageListDragCandidate()
+        {
+            SetPageListDragItemHighlight(false);
+
+            if (_pageListDragContainerContent != null)
+            {
+                _pageListDragContainerContent.RenderTransform = null;
+                _pageListDragContainerContent.RenderTransformOrigin = new Point(0, 0);
+            }
+            if (_pageListDragContainer != null)
+                _pageListDragContainer.ClearValue(Panel.ZIndexProperty);
+            if (_pageListDragIndicator != null)
+                _pageListDragIndicator.Visibility = Visibility.Collapsed;
+
+            _pageListDragCandidate = false;
+            _pageListDragActive = false;
+            _pageListDragListView = null;
+            _pageListDragScrollViewer = null;
+            _pageListDragFromIndex = -1;
+            _pageListDragCurrentIndex = -1;
+            _pageListDragItem = null;
+            _pageListDragContainer = null;
+            _pageListDragContainerContent = null;
+            _pageListDragTranslate = null;
+            _pageListDragIndicator = null;
+        }
+
+        /// <summary>开启/关闭被拖项的"抬起"视觉（半透明+阴影）。</summary>
+        private void SetPageListDragItemHighlight(bool isDragging)
+        {
+            if (_pageListDragItem != null)
+                _pageListDragItem.IsDragging = isDragging;
+        }
+
+        /// <summary>
+        /// 将第 fromPage 页的快照数据移动到第 toPage 页（1-based），区间内其余页顺移。
+        /// 搬移字段与新增/删除页保持一致：历史、多指状态、冻结状态、最后变更时间。
+        /// </summary>
+        private void MoveWhiteboardPageData(int fromPage, int toPage)
+        {
+            if (fromPage == toPage) return;
+
+            var history = TimeMachineHistories[fromPage];
+            var multiState = savedMultiTouchModeStates[fromPage];
+            var frozen = frozenPages[fromPage];
+            var lastUtc = pageLastUserInkMutationUtc[fromPage];
+
+            if (fromPage < toPage)
+            {
+                for (var i = fromPage; i < toPage; i++)
+                {
+                    TimeMachineHistories[i] = TimeMachineHistories[i + 1];
+                    savedMultiTouchModeStates[i] = savedMultiTouchModeStates[i + 1];
+                    frozenPages[i] = frozenPages[i + 1];
+                    pageLastUserInkMutationUtc[i] = pageLastUserInkMutationUtc[i + 1];
+                }
+            }
+            else
+            {
+                for (var i = fromPage; i > toPage; i--)
+                {
+                    TimeMachineHistories[i] = TimeMachineHistories[i - 1];
+                    savedMultiTouchModeStates[i] = savedMultiTouchModeStates[i - 1];
+                    frozenPages[i] = frozenPages[i - 1];
+                    pageLastUserInkMutationUtc[i] = pageLastUserInkMutationUtc[i - 1];
+                }
+            }
+
+            TimeMachineHistories[toPage] = history;
+            savedMultiTouchModeStates[toPage] = multiState;
+            frozenPages[toPage] = frozen;
+            pageLastUserInkMutationUtc[toPage] = lastUtc;
+        }
+
+        #region 鼠标/笔拖拽入口
+
+        /// <summary>
+        /// 列表选中变化时同步各数据项的 IsSelected 标记。
+        /// 选中样式由数据驱动（卡片描边），左右两个列表共享同一集合，天然对称。
+        /// </summary>
+        private void PageList_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (!(sender is ListView listView)) return;
+            for (var i = 0; i < blackBoardSidePageListViewObservableCollection.Count; i++)
+            {
+                blackBoardSidePageListViewObservableCollection[i].IsSelected = i == listView.SelectedIndex;
+            }
+        }
+
+        private void PageList_PreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            if (!(sender is ListView listView)) return;
+            // 仅记录候选，不在此捕获鼠标——否则普通点击的 MouseUp 会改道到列表，
+            // 缩略图切页将失效；捕获推迟到真正越过阈值开始拖拽时
+            TryBeginPageListDragCandidate(listView, e.GetPosition(listView), e.OriginalSource, requireHold: false);
+        }
+
+        private void PageList_PreviewMouseMove(object sender, MouseEventArgs e)
+        {
+            if (!(sender is ListView listView)) return;
+            if (!_pageListDragCandidate || _pageListDragListView != listView) return;
+
+            var wasActive = _pageListDragActive;
+            UpdatePageListDrag(listView, e.GetPosition(listView));
+            // 刚进入拖拽时捕获鼠标，保证拖动期间（含越出列表边缘）事件连续
+            if (!wasActive && _pageListDragActive)
+                listView.CaptureMouse();
+            e.Handled = true;
+        }
+
+        private void PageList_PreviewMouseUp(object sender, MouseButtonEventArgs e)
+        {
+            if (!(_pageListDragListView == sender)) return;
+            var wasDragging = _pageListDragActive;
+            EndPageListDrag();
+            // 拖拽结束时吞掉本次点击，避免触发缩略图切页
+            if (wasDragging) e.Handled = true;
+        }
+
+        private void PageList_LostMouseCapture(object sender, MouseEventArgs e)
+        {
+            // 捕获意外丢失（如窗口失活）时收尾，避免集合已移动而页数据未同步
+            if (_pageListDragListView == sender && _pageListDragActive)
+                EndPageListDrag();
+        }
+
+        #endregion
+
+        #endregion
     }
 }

--- a/Ink Canvas/Properties/RandomStrings.Designer.cs
+++ b/Ink Canvas/Properties/RandomStrings.Designer.cs
@@ -329,6 +329,18 @@ namespace Ink_Canvas.Properties
 
         public static string Random_QuickDraw_UseExternal => ResourceManager.GetString(nameof(Random_QuickDraw_UseExternal), _resourceCulture);
 
+        public static string Random_QuickDraw_FinalJump => ResourceManager.GetString(nameof(Random_QuickDraw_FinalJump), _resourceCulture);
+
+        public static string Random_QuickDraw_FinalJumpProbability => ResourceManager.GetString(nameof(Random_QuickDraw_FinalJumpProbability), _resourceCulture);
+
+        public static string Random_QuickDraw_FinalJumpDelay => ResourceManager.GetString(nameof(Random_QuickDraw_FinalJumpDelay), _resourceCulture);
+
+        public static string Random_QuickDraw_FinalJumpPulse => ResourceManager.GetString(nameof(Random_QuickDraw_FinalJumpPulse), _resourceCulture);
+
+        public static string Random_QuickDraw_FinalJumpPulseHint => ResourceManager.GetString(nameof(Random_QuickDraw_FinalJumpPulseHint), _resourceCulture);
+
+        public static string Random_QuickDraw_FinalJumpHint => ResourceManager.GetString(nameof(Random_QuickDraw_FinalJumpHint), _resourceCulture);
+
         public static string Random_QuickDraw_Title => ResourceManager.GetString(nameof(Random_QuickDraw_Title), _resourceCulture);
 
         public static string Random_Rand_ClickToImport => ResourceManager.GetString(nameof(Random_Rand_ClickToImport), _resourceCulture);

--- a/Ink Canvas/Properties/RandomStrings.en-US.resx
+++ b/Ink Canvas/Properties/RandomStrings.en-US.resx
@@ -483,6 +483,24 @@ If not installed, please download and install it from the official website. If a
   <data name="Random_QuickDraw_UseExternal" xml:space="preserve">
     <value>Use selected external caller for quick draw</value>
   </data>
+  <data name="Random_QuickDraw_FinalJump" xml:space="preserve">
+    <value>Quick draw result slides</value>
+  </data>
+  <data name="Random_QuickDraw_FinalJumpProbability" xml:space="preserve">
+    <value>Trigger probability</value>
+  </data>
+  <data name="Random_QuickDraw_FinalJumpDelay" xml:space="preserve">
+    <value>Slide delay (seconds)</value>
+  </data>
+  <data name="Random_QuickDraw_FinalJumpPulse" xml:space="preserve">
+    <value>Hop animation</value>
+  </data>
+  <data name="Random_QuickDraw_FinalJumpPulseHint" xml:space="preserve">
+    <value>The result briefly hops upward when it slides; when off, only the text changes without the hop</value>
+  </data>
+  <data name="Random_QuickDraw_FinalJumpHint" xml:space="preserve">
+    <value>When enabled, the quick draw result may appear to settle and then, with some chance, pause briefly and slide to another result, adding suspense to the draw</value>
+  </data>
   <data name="Random_QuickDraw_WindowTitle" xml:space="preserve">
     <value>Quick Draw</value>
   </data>

--- a/Ink Canvas/Properties/RandomStrings.resx
+++ b/Ink Canvas/Properties/RandomStrings.resx
@@ -483,6 +483,24 @@
   <data name="Random_QuickDraw_UseExternal" xml:space="preserve">
     <value>快抽调用所选外部点名</value>
   </data>
+  <data name="Random_QuickDraw_FinalJump" xml:space="preserve">
+    <value>快抽结果滑动</value>
+  </data>
+  <data name="Random_QuickDraw_FinalJumpProbability" xml:space="preserve">
+    <value>触发概率</value>
+  </data>
+  <data name="Random_QuickDraw_FinalJumpDelay" xml:space="preserve">
+    <value>跳变间隔（秒）</value>
+  </data>
+  <data name="Random_QuickDraw_FinalJumpPulse" xml:space="preserve">
+    <value>跳动动画</value>
+  </data>
+  <data name="Random_QuickDraw_FinalJumpPulseHint" xml:space="preserve">
+    <value>结果滑动时向上轻跳一下的落点动画，关闭后仅更换文字不再跳动</value>
+  </data>
+  <data name="Random_QuickDraw_FinalJumpHint" xml:space="preserve">
+    <value>开启后，快抽结果看似定格时，还有一定概率停顿片刻再滑动到另一个结果，增加抽选悬念</value>
+  </data>
   <data name="Random_QuickDraw_WindowTitle" xml:space="preserve">
     <value>快抽窗口</value>
   </data>

--- a/Ink Canvas/Properties/RandomStrings.zh-ME.resx
+++ b/Ink Canvas/Properties/RandomStrings.zh-ME.resx
@@ -483,6 +483,24 @@
   <data name="Random_QuickDraw_UseExternal" xml:space="preserve">
     <value>快抽调用所选外部点名</value>
   </data>
+  <data name="Random_QuickDraw_FinalJump" xml:space="preserve">
+    <value>快抽结果滑动</value>
+  </data>
+  <data name="Random_QuickDraw_FinalJumpProbability" xml:space="preserve">
+    <value>触发概率</value>
+  </data>
+  <data name="Random_QuickDraw_FinalJumpDelay" xml:space="preserve">
+    <value>跳变间隔（秒）</value>
+  </data>
+  <data name="Random_QuickDraw_FinalJumpPulse" xml:space="preserve">
+    <value>跳动动画</value>
+  </data>
+  <data name="Random_QuickDraw_FinalJumpPulseHint" xml:space="preserve">
+    <value>结果滑动时向上轻跳一下的落点动画，关闭后仅更换文字不再跳动</value>
+  </data>
+  <data name="Random_QuickDraw_FinalJumpHint" xml:space="preserve">
+    <value>开启后，快抽结果看似定格时，还有一定概率停顿片刻再滑动到另一个结果，增加抽选悬念</value>
+  </data>
   <data name="Random_QuickDraw_WindowTitle" xml:space="preserve">
     <value>快抽窗口</value>
   </data>

--- a/Ink Canvas/Resources/Settings.cs
+++ b/Ink Canvas/Resources/Settings.cs
@@ -1617,6 +1617,14 @@ namespace Ink_Canvas
         public bool EnableQuickDraw { get; set; } = true;
         [JsonProperty("quickDrawExternalCaller")]
         public bool QuickDrawExternalCaller { get; set; }
+        [JsonProperty("enableQuickDrawFinalJump")]
+        public bool EnableQuickDrawFinalJump { get; set; }
+        [JsonProperty("quickDrawFinalJumpProbability")]
+        public double QuickDrawFinalJumpProbability { get; set; } = 0.3;
+        [JsonProperty("quickDrawFinalJumpSettleDelaySeconds")]
+        public double QuickDrawFinalJumpSettleDelaySeconds { get; set; } = 0.5;
+        [JsonProperty("enableQuickDrawFinalJumpPulse")]
+        public bool EnableQuickDrawFinalJumpPulse { get; set; } = true;
         [JsonProperty("nameRosters")]
         public List<NameRoster> NameRosters { get; set; } = new List<NameRoster>();
         [JsonProperty("selectedNameRosterGuid")]

--- a/Ink Canvas/Windows/QuickDrawWindow.xaml.cs
+++ b/Ink Canvas/Windows/QuickDrawWindow.xaml.cs
@@ -5,6 +5,8 @@ using System.IO;
 using System.Linq;
 using System.Windows;
 using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Animation;
 
 namespace Ink_Canvas
 {
@@ -15,7 +17,12 @@ namespace Ink_Canvas
     {
         private Random random = new Random();
         private int autoCloseWaitTime = 2500; // 自动关闭等待时间（毫秒）
-        private List<string> nameList = new List<string>(); // 名单列表 
+        private List<string> nameList = new List<string>(); // 名单列表
+
+        private bool _finalJumpEnabled;               // "最后一跳"开关
+        private double _finalJumpProbability = 0.3;   // 最后一跳触发概率（0-1）
+        private double _finalJumpSettleDelaySeconds = 0.5; // "假最终"跳变间隔（秒）：定格多久后变成下一个
+        private bool _finalJumpPulse = true;          // 落点轻跳脉冲动画开关
 
         public QuickDrawWindow()
         {
@@ -42,6 +49,10 @@ namespace Ink_Canvas
                 if (MainWindow.Settings?.RandSettings != null)
                 {
                     autoCloseWaitTime = (int)MainWindow.Settings.RandSettings.RandWindowOnceCloseLatency * 1000;
+                    _finalJumpEnabled = MainWindow.Settings.RandSettings.EnableQuickDrawFinalJump;
+                    _finalJumpProbability = Math.Max(0, Math.Min(1, MainWindow.Settings.RandSettings.QuickDrawFinalJumpProbability));
+                    _finalJumpSettleDelaySeconds = Math.Max(0, MainWindow.Settings.RandSettings.QuickDrawFinalJumpSettleDelaySeconds);
+                    _finalJumpPulse = MainWindow.Settings.RandSettings.EnableQuickDrawFinalJumpPulse;
                 }
             }
             catch (Exception ex)
@@ -168,15 +179,20 @@ namespace Ink_Canvas
                 System.Threading.Thread.Sleep(sleepTime);
             }
 
-            // 动画结束，显示最终结果
-            Application.Current.Dispatcher.Invoke(() =>
+            // 动画结束：真最终走正常路径（降重抽选）
+            string finalName = Application.Current.Dispatcher.Invoke(() =>
             {
                 // 使用降重抽选方法选择最终名字
                 var selectedNames = NewStyleRollCallWindow.SelectNamesWithML(nameList, 1, random);
-                string finalName = selectedNames.Count > 0 ? selectedNames[0] : nameList[random.Next(0, nameList.Count)];
-                MainResultDisplay.Text = finalName;
+                return selectedNames.Count > 0 ? selectedNames[0] : nameList[random.Next(0, nameList.Count)];
+            });
 
-                // 更新历史记录
+            // "快抽结果滑动"（若命中）：先快速随机亮一个假最终，停顿后滑到真最终
+            FinishWithOptionalFinalJump(finalName, nameList);
+
+            // 更新历史记录（仅记录真实最终结果，与历史数据线程一致）
+            Application.Current.Dispatcher.Invoke(() =>
+            {
                 NewStyleRollCallWindow.UpdateRollCallHistory(new List<string> { finalName });
             });
 
@@ -217,16 +233,21 @@ namespace Ink_Canvas
                 System.Threading.Thread.Sleep(sleepTime);
             }
 
-            // 动画结束，显示最终结果
-            Application.Current.Dispatcher.Invoke(() =>
+            // 动画结束：真最终走正常路径（降重抽选）
+            var numberList = Enumerable.Range(1, 60).Select(n => n.ToString()).ToList();
+            string finalNumber = Application.Current.Dispatcher.Invoke(() =>
             {
                 // 使用降重抽选方法选择最终数字
-                var numberList = Enumerable.Range(1, 60).Select(n => n.ToString()).ToList();
                 var selectedNumbers = NewStyleRollCallWindow.SelectNamesWithML(numberList, 1, random);
-                string finalNumber = selectedNumbers.Count > 0 ? selectedNumbers[0] : random.Next(1, 61).ToString();
-                MainResultDisplay.Text = finalNumber;
+                return selectedNumbers.Count > 0 ? selectedNumbers[0] : random.Next(1, 61).ToString();
+            });
 
-                // 更新历史记录
+            // "快抽结果滑动"（若命中）：先快速随机亮一个假最终，停顿后滑到真最终
+            FinishWithOptionalFinalJump(finalNumber, numberList);
+
+            // 更新历史记录（仅记录真实最终结果，与历史数据线程一致）
+            Application.Current.Dispatcher.Invoke(() =>
+            {
                 NewStyleRollCallWindow.UpdateRollCallHistory(new List<string> { finalNumber });
             });
 
@@ -239,6 +260,76 @@ namespace Ink_Canvas
                     Close();
                 });
             }).Start();
+        }
+
+        /// <summary>
+        /// "快抽结果滑动"整蛊表演：真最终已由正常路径（降重抽选）确定。
+        /// 按概率先快速随机亮一个与真最终不同的"假最终"，停顿后滑到真最终，
+        /// 落点按设置播放轻跳脉冲动画。在动画线程上调用。
+        /// </summary>
+        private void FinishWithOptionalFinalJump(string trueResult, List<string> allCandidates)
+        {
+            // 不跳：直接显示真最终
+            if (!_finalJumpEnabled || allCandidates.Count <= 1 || random.NextDouble() >= _finalJumpProbability)
+            {
+                Application.Current.Dispatcher.Invoke(() =>
+                {
+                    MainResultDisplay.Text = trueResult;
+                });
+                return;
+            }
+
+            // 假最终：从名单里快速随机挑一位（与真最终不同即可，纯展示用）
+            var fakePool = allCandidates.Where(c => c != trueResult).ToList();
+            if (fakePool.Count == 0)
+            {
+                Application.Current.Dispatcher.Invoke(() =>
+                {
+                    MainResultDisplay.Text = trueResult;
+                });
+                return;
+            }
+            string fakeResult = fakePool[random.Next(fakePool.Count)];
+
+            Application.Current.Dispatcher.Invoke(() =>
+            {
+                MainResultDisplay.Text = fakeResult;
+            });
+
+            // 按设置的跳变间隔停顿：让学生以为抽中了
+            System.Threading.Thread.Sleep((int)(_finalJumpSettleDelaySeconds * 1000));
+
+            // 滑到真最终，落点按设置播放轻跳脉冲
+            Application.Current.Dispatcher.Invoke(() =>
+            {
+                MainResultDisplay.Text = trueResult;
+                if (_finalJumpPulse)
+                {
+                    PlayFinalHopPulse();
+                }
+            });
+        }
+
+        /// <summary>
+        /// 最后一跳的落点脉冲：结果整体轻轻向上一跳再回位，让这次跳格显得刻意而俏皮
+        /// </summary>
+        private void PlayFinalHopPulse()
+        {
+            var translate = new TranslateTransform(0, 0);
+            ResultGrid.RenderTransform = translate;
+
+            var hop = new DoubleAnimationUsingKeyFrames();
+            hop.KeyFrames.Add(new EasingDoubleKeyFrame(0, KeyTime.FromTimeSpan(TimeSpan.Zero)));
+            hop.KeyFrames.Add(new EasingDoubleKeyFrame(-10, KeyTime.FromTimeSpan(TimeSpan.FromMilliseconds(110)))
+            {
+                EasingFunction = new QuadraticEase { EasingMode = EasingMode.EaseOut }
+            });
+            hop.KeyFrames.Add(new EasingDoubleKeyFrame(0, KeyTime.FromTimeSpan(TimeSpan.FromMilliseconds(250)))
+            {
+                EasingFunction = new QuadraticEase { EasingMode = EasingMode.EaseIn }
+            });
+
+            translate.BeginAnimation(TranslateTransform.YProperty, hop);
         }
 
 

--- a/Ink Canvas/Windows/SettingsViews/Pages/RandomDrawPage.xaml
+++ b/Ink Canvas/Windows/SettingsViews/Pages/RandomDrawPage.xaml
@@ -91,6 +91,43 @@
                         </ikw:SimpleStackPanel>
                     </ui:SettingsCard>
 
+                    <ui:SettingsExpander Header="{x:Static props:RandomStrings.Random_QuickDraw_FinalJump}"
+                            Description="{x:Static props:RandomStrings.Random_QuickDraw_FinalJumpHint}"
+                            IsExpanded="{Binding IsOn, ElementName=ToggleSwitchQuickDrawFinalJump, Mode=OneWay}">
+                        <ui:ToggleSwitch x:Name="ToggleSwitchQuickDrawFinalJump"
+                                        Toggled="ToggleSwitchQuickDrawFinalJump_Toggled" />
+                        <ui:SettingsExpander.Items>
+                            <ui:SettingsCard Header="{x:Static props:RandomStrings.Random_QuickDraw_FinalJumpProbability}">
+                                <ikw:SimpleStackPanel Orientation="Horizontal" Spacing="8">
+                                    <TextBlock x:Name="QuickDrawFinalJumpProbabilityText"
+                                               VerticalAlignment="Center" FontFamily="Consolas" TextAlignment="Right"/>
+                                    <Slider x:Name="QuickDrawFinalJumpProbabilitySlider"
+                                            Minimum="0" Maximum="100" Width="200"
+                                            IsSnapToTickEnabled="True" Value="30"
+                                            TickFrequency="5" TickPlacement="None"
+                                            ValueChanged="QuickDrawFinalJumpProbabilitySlider_ValueChanged" />
+                                </ikw:SimpleStackPanel>
+                            </ui:SettingsCard>
+                            <ui:SettingsCard Header="{x:Static props:RandomStrings.Random_QuickDraw_FinalJumpDelay}">
+                                <ikw:SimpleStackPanel Orientation="Horizontal" Spacing="8">
+                                    <TextBlock x:Name="QuickDrawFinalJumpDelayText"
+                                               VerticalAlignment="Center" FontFamily="Consolas" TextAlignment="Right"/>
+                                    <Slider x:Name="QuickDrawFinalJumpDelaySlider"
+                                            Minimum="0.5" Maximum="3" Width="200"
+                                            IsSnapToTickEnabled="True" Value="0.5"
+                                            TickFrequency="0.1" TickPlacement="None"
+                                            ValueChanged="QuickDrawFinalJumpDelaySlider_ValueChanged" />
+                                </ikw:SimpleStackPanel>
+                            </ui:SettingsCard>
+                            <ui:SettingsCard Header="{x:Static props:RandomStrings.Random_QuickDraw_FinalJumpPulse}"
+                                    Description="{x:Static props:RandomStrings.Random_QuickDraw_FinalJumpPulseHint}">
+                                <ui:ToggleSwitch x:Name="ToggleSwitchQuickDrawFinalJumpPulse"
+                                                IsOn="True"
+                                                Toggled="ToggleSwitchQuickDrawFinalJumpPulse_Toggled" />
+                            </ui:SettingsCard>
+                        </ui:SettingsExpander.Items>
+                    </ui:SettingsExpander>
+
                     <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}"
                         Text="{x:Static props:RandomStrings.Random_Roster_SectionHeader}" />
 

--- a/Ink Canvas/Windows/SettingsViews/Pages/RandomDrawPage.xaml.cs
+++ b/Ink Canvas/Windows/SettingsViews/Pages/RandomDrawPage.xaml.cs
@@ -38,6 +38,8 @@ namespace Ink_Canvas.Windows.SettingsViews.Pages
             UpdateSliderText(MLAvoidanceWeightSlider, MLAvoidanceWeightText, "{0:F1}");
             UpdateSliderText(TimerVolumeSlider, TimerVolumeText, "{0:F1}");
             UpdateSliderText(ProgressiveReminderVolumeSlider, ProgressiveReminderVolumeText, "{0:F1}");
+            UpdateQuickDrawFinalJumpProbabilityText();
+            UpdateSliderText(QuickDrawFinalJumpDelaySlider, QuickDrawFinalJumpDelayText, "{0:F1}");
         }
 
         private void UpdateSliderText(Slider slider, TextBlock textBlock, string format)
@@ -62,6 +64,10 @@ namespace Ink_Canvas.Windows.SettingsViews.Pages
             ToggleSwitchShowRandomAndSingleDraw.IsOn = settings.RandSettings.ShowRandomAndSingleDraw;
             ToggleSwitchEnableQuickDraw.IsOn = settings.RandSettings.EnableQuickDraw;
             ToggleSwitchQuickDrawExternalCaller.IsOn = settings.RandSettings.QuickDrawExternalCaller;
+            ToggleSwitchQuickDrawFinalJump.IsOn = settings.RandSettings.EnableQuickDrawFinalJump;
+            QuickDrawFinalJumpProbabilitySlider.Value = settings.RandSettings.QuickDrawFinalJumpProbability * 100;
+            QuickDrawFinalJumpDelaySlider.Value = settings.RandSettings.QuickDrawFinalJumpSettleDelaySeconds;
+            ToggleSwitchQuickDrawFinalJumpPulse.IsOn = settings.RandSettings.EnableQuickDrawFinalJumpPulse;
             ToggleSwitchExternalCaller.IsOn = settings.RandSettings.DirectCallCiRand;
             ComboBoxExternalCallerType.SelectedIndex = settings.RandSettings.ExternalCallerType;
 
@@ -144,6 +150,53 @@ namespace Ink_Canvas.Windows.SettingsViews.Pages
         {
             if (!_isLoaded) return;
             SettingsManager.Settings.RandSettings.QuickDrawExternalCaller = ToggleSwitchQuickDrawExternalCaller.IsOn;
+            SettingsManager.SaveSettingsToFile();
+        }
+
+        private void ToggleSwitchQuickDrawFinalJump_Toggled(object sender, RoutedEventArgs e)
+        {
+            if (!_isLoaded) return;
+            // 概率滑杆的展开/收起由 LabeledSettingsCard 的 ExpandableContent 按 IsOn 自动处理
+            SettingsManager.Settings.RandSettings.EnableQuickDrawFinalJump = ToggleSwitchQuickDrawFinalJump.IsOn;
+            SettingsManager.SaveSettingsToFile();
+        }
+
+        private void QuickDrawFinalJumpProbabilitySlider_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
+        {
+            UpdateQuickDrawFinalJumpProbabilityText();
+            if (!_isLoaded) return;
+            var slider = QuickDrawFinalJumpProbabilitySlider;
+            var val = Math.Round(slider.Value);
+            // 仅当四舍五入纠正了显示值时才回写；那次 set 会重入 ValueChanged 完成保存。
+            if (slider.Value != val)
+            {
+                slider.Value = val;
+                return;
+            }
+            SettingsManager.Settings.RandSettings.QuickDrawFinalJumpProbability = val / 100.0;
+            SettingsManager.SaveSettingsToFile();
+        }
+
+        private void UpdateQuickDrawFinalJumpProbabilityText()
+        {
+            if (QuickDrawFinalJumpProbabilitySlider == null || QuickDrawFinalJumpProbabilityText == null) return;
+            QuickDrawFinalJumpProbabilityText.Text = $"{(int)Math.Round(QuickDrawFinalJumpProbabilitySlider.Value)}%";
+        }
+
+        private void ToggleSwitchQuickDrawFinalJumpPulse_Toggled(object sender, RoutedEventArgs e)
+        {
+            if (!_isLoaded) return;
+            SettingsManager.Settings.RandSettings.EnableQuickDrawFinalJumpPulse = ToggleSwitchQuickDrawFinalJumpPulse.IsOn;
+            SettingsManager.SaveSettingsToFile();
+        }
+
+        private void QuickDrawFinalJumpDelaySlider_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
+        {
+            UpdateSliderText(QuickDrawFinalJumpDelaySlider, QuickDrawFinalJumpDelayText, "{0:F1}");
+            if (!_isLoaded) return;
+            var val = Math.Round(QuickDrawFinalJumpDelaySlider.Value, 2);
+            QuickDrawFinalJumpDelaySlider.Value = val;
+            SettingsManager.Settings.RandSettings.QuickDrawFinalJumpSettleDelaySeconds = val;
             SettingsManager.SaveSettingsToFile();
         }
 

--- a/rules/Ink Canvas 设置完整目录.md
+++ b/rules/Ink Canvas 设置完整目录.md
@@ -503,7 +503,11 @@
 │   │   ├── LabeledSettingsCard: 使用外部调用 → ToggleSwitch
 │   │   ├── SettingsCard: 外部调用类型 → ComboBox
 │   │   ├── SettingsCard: 单次关闭延迟 → Slider
-│   │   └── SettingsCard: 单次最大人数 → Slider
+│   │   ├── SettingsCard: 单次最大人数 → Slider
+│   │   └── SettingsExpander: 快抽结果滑动 → ToggleSwitch（开则展开）
+│   │       ├── SettingsCard: 触发概率 → Slider
+│   │       ├── SettingsCard: 跳变间隔（秒） → Slider
+│   │       └── SettingsCard: 跳动动画 → ToggleSwitch
 │   ├── TextBlock "背景设置"
 │   │   └── SettingsCard: 背景选择 → Button × 2 + ComboBox
 │   ├── TextBlock "新 UI"


### PR DESCRIPTION
### 白板页面缩略图拖拽排序

- 鼠标/笔即拖即动，触摸长按 450ms 进入（不与列表滚动冲突）；被拖项跟手放大带阴影，主题色插入线标记落点，首位/末位均可达
- 松手一次性落盘：页历史/多指状态/冻结状态/变更时间四数组随页搬移，当前页跟随被拖页，非当前页画布无重绘
- 选中小蓝条按弹出侧镜像（均朝向屏幕中央）；缩略图按画布比例实时填满、无白边；页列表面板加长至约屏幕高度 60%

### #快抽结果滑动

- 快抽结果看似定格后，按概率停顿片刻（0.5–3 秒可调）再滑动到另一个结果，落点配轻跳脉冲（可关）
- 真最终始终走降重抽选正常路径，"避免重复抽取"不受影响；历史只记真最终
- 新设置（SettingsExpander 下拉式卡片，与托盘图标设置同款）：开关（默认关）、触发概率（0–100%，默认 30%）、跳变间隔（0.5–3 秒，默认 0.5）、跳动动画（默认开）
- 名单与数字模式均支持；名单仅 1 人时静默跳过