### PR TITLE
fix: 修复上下红外框触摸屏手掌擦橡皮过大的问题

### DIFF
--- a/Ink Canvas/Ink/Native/NativeInkInputRouter.cs
+++ b/Ink Canvas/Ink/Native/NativeInkInputRouter.cs
@@ -300,18 +300,21 @@ namespace Ink_Canvas.Ink.Native
             if (policy.IsSpecialScreen && policy.TouchMultiplier == 0)
                 return false;
 
-            var boundWidth = policy.IsQuadIr
-                ? Math.Sqrt(Math.Max(0, pointer.ContactWidthDip * pointer.ContactHeightDip))
-                : pointer.ContactWidthDip;
+            var boundWidth = PalmEraserGeometry.GetEffectiveContactWidthDip(
+                pointer.ContactWidthDip,
+                pointer.ContactHeightDip,
+                policy.IsQuadIr);
             var threshold = policy.BoundsWidthDip
                             * policy.ThresholdFactor
                             * policy.SensitivityMultiplier;
             if (boundWidth <= policy.BoundsWidthDip || boundWidth <= threshold)
                 return false;
 
-            eraserWidthDip = boundWidth
-                             * policy.EraserSizeFactor
-                             * (policy.IsSpecialScreen ? policy.TouchMultiplier : 1);
+            eraserWidthDip = PalmEraserGeometry.ApplyPalmEraserSize(
+                boundWidth,
+                policy.EraserSizeFactor,
+                policy.IsSpecialScreen,
+                policy.TouchMultiplier);
             return true;
         }
 

--- a/Ink Canvas/Ink/PalmEraserGeometry.cs
+++ b/Ink Canvas/Ink/PalmEraserGeometry.cs
@@ -1,0 +1,59 @@
+using System;
+
+namespace Ink_Canvas.Ink
+{
+    /// <summary>
+    /// 手掌擦接触尺寸计算。
+    /// 上下红外等触摸框可能把接触矩形某一轴异常放大（例如接近全屏宽度的长条），
+    /// 这里把异常细长接触折算为几何平均宽度，并限制最终手掌橡皮大小。
+    /// </summary>
+    internal static class PalmEraserGeometry
+    {
+        /// <summary>
+        /// 手掌橡皮最大宽度（DIP）。用于防止上下红外等设备上报的异常接触矩形
+        /// 把橡皮放大到远超真实手掌的程度。
+        /// </summary>
+        internal const double MaxPalmEraserWidthDip = 200;
+
+        /// <summary>
+        /// 接触矩形长宽比超过该值时，认为某一轴可能是红外框的异常放大结果，
+        /// 改用几何平均 sqrt(width*height) 来估算有效接触宽度。
+        /// </summary>
+        private const double ElongatedAspectRatioThreshold = 3.0;
+
+        internal static double GetEffectiveContactWidthDip(
+            double contactWidthDip,
+            double contactHeightDip,
+            bool isQuadIr)
+        {
+            if (contactWidthDip <= 0)
+                return 0;
+
+            // 部分设备不提供高度，仍回退到宽度，避免破坏原有行为。
+            if (contactHeightDip <= 0)
+                return contactWidthDip;
+
+            var min = Math.Min(contactWidthDip, contactHeightDip);
+            var max = Math.Max(contactWidthDip, contactHeightDip);
+            var elongated = min <= 0 || max / min > ElongatedAspectRatioThreshold;
+
+            if (isQuadIr || elongated)
+                return Math.Sqrt(Math.Max(0, contactWidthDip * contactHeightDip));
+
+            return contactWidthDip;
+        }
+
+        internal static double ApplyPalmEraserSize(
+            double effectiveContactWidthDip,
+            double eraserSizeFactor,
+            bool isSpecialScreen,
+            double touchMultiplier)
+        {
+            var widthDip = effectiveContactWidthDip * eraserSizeFactor;
+            if (isSpecialScreen)
+                widthDip *= touchMultiplier;
+
+            return Math.Min(widthDip, MaxPalmEraserWidthDip);
+        }
+    }
+}

--- a/Ink Canvas/MainWindow_cs/MW_TouchEvents.cs
+++ b/Ink Canvas/MainWindow_cs/MW_TouchEvents.cs
@@ -1864,8 +1864,10 @@ namespace Ink_Canvas
         public double GetTouchBoundWidth(TouchEventArgs e)
         {
             var args = e.GetTouchPoint(null).Bounds;
-            if (!Settings.Advanced.IsQuadIR) return args.Width;
-            return Math.Sqrt(args.Width * args.Height);
+            return Ink_Canvas.Ink.PalmEraserGeometry.GetEffectiveContactWidthDip(
+                args.Width,
+                args.Height,
+                Settings.Advanced.IsQuadIR);
         }
 
         /// <summary>
@@ -2086,18 +2088,21 @@ namespace Ink_Canvas
 
                     if (boundWidth > BoundsWidth * EraserThresholdValue * thresholdMultiplier)
                     {
-                        boundWidth *= Settings.Startup.IsEnableNibMode
+                        var eraserSizeFactor = Settings.Startup.IsEnableNibMode
                             ? Settings.Advanced.NibModeBoundsWidthEraserSize
                             : Settings.Advanced.FingerModeBoundsWidthEraserSize;
+                        var palmEraserWidth = Ink_Canvas.Ink.PalmEraserGeometry.ApplyPalmEraserSize(
+                            boundWidth,
+                            eraserSizeFactor,
+                            Settings.Advanced.IsSpecialScreen,
+                            Settings.Advanced.TouchMultiplier);
 
-                        if (Settings.Advanced.IsSpecialScreen)
-                            boundWidth *= Settings.Advanced.TouchMultiplier;
                         palmEraserPreviousEditingMode = inkCanvas.EditingMode;
                         inkCanvas.EditingMode = InkCanvasEditingMode.EraseByPoint;
                         isPalmEraserActive = true;
 
                         EnableEraserOverlay();
-                        eraserWidth = boundWidth;
+                        eraserWidth = palmEraserWidth;
                         UpdateEraserStyle();
                         touchPoint = e.GetTouchPoint(inkCanvas);
                         EraserOverlay_PointerDown(sender);

--- a/InkCanvas.NativeInk.Tests/InkCanvas.NativeInk.Tests.csproj
+++ b/InkCanvas.NativeInk.Tests/InkCanvas.NativeInk.Tests.csproj
@@ -17,6 +17,7 @@
     <Compile Include="..\Ink Canvas\Ink\Native\NativeInkPerfProbe.cs" Link="Ink\Native\NativeInkPerfProbe.cs" />
     <Compile Include="..\Ink Canvas\Ink\Native\NativePointerUpdatePump.cs" Link="Ink\Native\NativePointerUpdatePump.cs" />
     <Compile Include="..\Ink Canvas\Ink\Native\NativeInkInputRouter.cs" Link="Ink\Native\NativeInkInputRouter.cs" />
+    <Compile Include="..\Ink Canvas\Ink\PalmEraserGeometry.cs" Link="Ink\PalmEraserGeometry.cs" />
     <Compile Include="..\Ink Canvas\Ink\Native\NativePointerInputBatch.cs" Link="Ink\Native\NativePointerInputBatch.cs" />
     <Compile Include="..\Ink Canvas\Ink\Native\NativePointerTimestampConverter.cs" Link="Ink\Native\NativePointerTimestampConverter.cs" />
     <Compile Include="..\Ink Canvas\Ink\Native\WetInkCommandMailbox.cs" Link="Ink\Native\WetInkCommandMailbox.cs" />

--- a/InkCanvas.NativeInk.Tests/NativeInkCoreTests.cs
+++ b/InkCanvas.NativeInk.Tests/NativeInkCoreTests.cs
@@ -40,6 +40,9 @@ namespace InkCanvas.NativeInk.Tests
             Run(nameof(RouterMapsLogicalTools), RouterMapsLogicalTools);
             Run(nameof(RouterPrefersMultiTouchWritingOverPalmErase), RouterPrefersMultiTouchWritingOverPalmErase);
             Run(nameof(RouterAppliesQuadIrPalmThresholdAndSpecialMultiplier), RouterAppliesQuadIrPalmThresholdAndSpecialMultiplier);
+            Run(nameof(RouterUsesGeometricMeanForElongatedTopBottomIrPalm), RouterUsesGeometricMeanForElongatedTopBottomIrPalm);
+            Run(nameof(RouterKeepsWidthForNormalPalmContact), RouterKeepsWidthForNormalPalmContact);
+            Run(nameof(RouterCapsPalmEraserWidth), RouterCapsPalmEraserWidth);
             Run(nameof(RouterAllowsDelayedTwoFingerTakeover), RouterAllowsDelayedTwoFingerTakeover);
             Run(nameof(RouterKeepsCapturedInkAndSuppressesBarrelPoints), RouterKeepsCapturedInkAndSuppressesBarrelPoints);
             Run(nameof(PointerBatchCopiesSamples), PointerBatchCopiesSamples);
@@ -538,6 +541,67 @@ namespace InkCanvas.NativeInk.Tests
                     LogicalInkTool.Pen,
                     palm: Palm(enabled: true, isSpecialScreen: true, touchMultiplier: 0)));
             Equal(NativeInputRoute.Ink, disabledOnSpecialScreen.Route);
+        }
+
+        private static void RouterUsesGeometricMeanForElongatedTopBottomIrPalm()
+        {
+            // 上下红外框常见异常：接触矩形接近全宽长条（width 异常大、height 接近真实手掌）。
+            // 非四边红外模式下也应使用几何平均，避免橡皮被放大到远超手掌。
+            var decision = NativeInkInputRouter.DecideDown(
+                Pointer(NativeInkInputKind.Touch, contactWidthDip: 1920, contactHeightDip: 120),
+                Context(
+                    LogicalInkTool.Pen,
+                    palm: Palm(
+                        enabled: true,
+                        isQuadIr: false,
+                        isSpecialScreen: true,
+                        boundsWidthDip: 10,
+                        thresholdFactor: 2,
+                        sensitivityMultiplier: 2,
+                        eraserSizeFactor: 0.8,
+                        touchMultiplier: 0.3)));
+            Equal(NativeInputRoute.PointErase, decision.Route);
+            True(Math.Abs(decision.PalmEraserWidthDip - 115.2d) < 0.001);
+        }
+
+        private static void RouterKeepsWidthForNormalPalmContact()
+        {
+            // 普通触摸屏接触矩形不细长时，继续使用宽度，避免改变原有行为。
+            var decision = NativeInkInputRouter.DecideDown(
+                Pointer(NativeInkInputKind.Touch, contactWidthDip: 80, contactHeightDip: 100),
+                Context(
+                    LogicalInkTool.Pen,
+                    palm: Palm(
+                        enabled: true,
+                        isQuadIr: false,
+                        isSpecialScreen: false,
+                        boundsWidthDip: 10,
+                        thresholdFactor: 2,
+                        sensitivityMultiplier: 2,
+                        eraserSizeFactor: 0.8,
+                        touchMultiplier: 1)));
+            Equal(NativeInputRoute.PointErase, decision.Route);
+            Equal(64d, decision.PalmEraserWidthDip);
+        }
+
+        private static void RouterCapsPalmEraserWidth()
+        {
+            // 即使两个轴都异常大，最终手掌橡皮也不能超过保护上限。
+            var decision = NativeInkInputRouter.DecideDown(
+                Pointer(NativeInkInputKind.Touch, contactWidthDip: 500, contactHeightDip: 500),
+                Context(
+                    LogicalInkTool.Pen,
+                    palm: Palm(
+                        enabled: true,
+                        isQuadIr: false,
+                        isSpecialScreen: false,
+                        boundsWidthDip: 10,
+                        thresholdFactor: 2,
+                        sensitivityMultiplier: 2,
+                        eraserSizeFactor: 1,
+                        touchMultiplier: 1)));
+            Equal(NativeInputRoute.PointErase, decision.Route);
+            Equal(Ink_Canvas.Ink.PalmEraserGeometry.MaxPalmEraserWidthDip, decision.PalmEraserWidthDip);
         }
 
         private static void RouterAllowsDelayedTwoFingerTakeover()


### PR DESCRIPTION
## 问题

在具有上下红外框的触摸屏上使用“手掌擦”时，橡皮尺寸巨大，远超实际手掌。

## 原因

非四边红外路径直接使用接触矩形的 Width 作为手掌擦尺寸。上下红外框可能把接触矩形某一轴上报为接近全屏宽度的异常长条，导致手掌擦被异常放大。

## 修改

- 新增 `PalmEraserGeometry`，统一计算有效接触宽度：异常细长接触使用 `sqrt(width * height)` 近似真实手掌尺寸，并增加 200 DIP 上限。
- `MW_TouchEvents.GetTouchBoundWidth()` 和手掌擦激活逻辑接入新计算。
- `NativeInkInputRouter.TryGetPalmEraserWidth()` 同步同一逻辑，保持两处公式一致。
- 新增 NativeInk 测试：上下红外异常长条场景、普通接触不回归、手掌橡皮最大宽度保护。

## 验证

- 测试项目构建通过。
- 新增手掌擦路由测试全部通过。
- 主项目构建通过，0 错误。